### PR TITLE
ci: add Conventional Commits PR title check

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,33 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, edited, synchronize, reopened ]
+
+permissions: {}
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false


### PR DESCRIPTION
## Summary

- Port the PR title validation workflow from pyvista-js
- Uses `amannn/action-semantic-pull-request@v5` to enforce Conventional Commits format
- Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert

## Test plan

- [x] Verify this PR's title passes the check
- [ ] Verify a PR with invalid title (e.g., "update stuff") is rejected