### PR TITLE
ci: add workflow to update uv.lock on release-please PRs

### DIFF
--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -13,6 +13,7 @@ jobs:
   uv-lock:
     if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
+    environment: release-please
     permissions:
       contents: write
     steps:
@@ -20,6 +21,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -31,6 +33,7 @@ jobs:
         run: |
           git config user.name "pyvista-bot"
           git config user.email "pyvista-bot@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.RELEASE_PLEASE_TOKEN }}@github.com/${{ github.repository }}.git
           git add uv.lock
           git diff --cached --quiet || git commit -m "chore: update uv.lock"
           git push


### PR DESCRIPTION
## Summary

This PR adds a new GitHub Actions workflow (`.github/workflows/uv-lock.yml`) that automatically keeps `uv.lock` up to date when release-please creates or updates a PR that modifies `pyproject.toml`.

- The workflow is triggered on pull requests targeting `main` that touch `pyproject.toml`
- It only runs when the PR branch name starts with `release-please--` (i.e., release-please PRs)
- It installs `uv`, runs `uv lock` to regenerate the lockfile, and commits the updated `uv.lock` back to the PR branch
- This ensures the lockfile stays consistent with dependency changes introduced by release-please without requiring manual intervention

## Test plan

- [ ] Verify the workflow file is valid YAML and parses correctly
- [ ] Confirm the workflow only triggers on `release-please--` prefixed branches
- [ ] Confirm `uv.lock` is committed and pushed back to the PR branch after a release-please PR modifies `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)