### PR TITLE
fix: white screen when using contour filter in JupyterLite

### DIFF
--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -1001,12 +1001,12 @@ async function applyContourFilter(
   const ComponentsOne = 1;
   const scalars = vtk.vtkFloatArray({
     numberOfComponents: ComponentsOne,
-    values: Float32Array.from(scalarData),
     name: scalarName,
   });
+  await scalars.setArray(Float32Array.from(scalarData));
   const pd = await inputPd.getPointData();
-  pd.addArray(scalars);
-  pd.setActiveScalars(scalarName);
+  await pd.addArray(scalars);
+  await pd.setActiveScalars(scalarName);
 
   return applyContourManual(vtk, inputPd, values, scalarName);
 }
@@ -1024,9 +1024,13 @@ function collectEdgeIntersections(
   inPoints: Float32Array | Uint32Array,
 ): number[] {
   const edgePoints: number[] = [];
+  const Epsilon = 1e-10;
   for (const edge of tri) {
     const [ai, bi, sa, sb] = edge;
-    if ((sa <= value && value < sb) || (sb <= value && value < sa)) {
+    // Use epsilon for floating point comparison
+    const minVal = Math.min(sa, sb) - Epsilon;
+    const maxVal = Math.max(sa, sb) + Epsilon;
+    if (value >= minVal && value <= maxVal && Math.abs(sa - sb) > Epsilon) {
       const t = (value - sa) / (sb - sa);
       edgePoints.push(
         at(inPoints, ai * PointStride + Xoffset) +


### PR DESCRIPTION
## Summary

Fixes the issue where `PolyData.contour().plot()` shows a white screen in JupyterLite environments.

## Problem

The Examples code at https://pyvista-wasm.readthedocs.io/en/latest/api/_autosummary/pyvista_wasm.PolyData.contour.html would only show a white screen when executed in JupyterLite, without displaying any contour lines.

## Root Cause

1. **applyContourFilter function**: The scalar values were being passed directly to the `vtkFloatArray` constructor, but VTK.wasm requires using the `setArray` method to set the array data properly.

2. **collectEdgeIntersections function**: Used strict equality comparisons (`sa <= value && value < sb`) for floating-point numbers, which could fail due to numerical precision issues, resulting in no contour lines being found.