### PR TITLE
fix: white screen when using contour filter in JupyterLite

### DIFF
--- a/src/pyvista_wasm/mesh.py
+++ b/src/pyvista_wasm/mesh.py
@@ -743,6 +743,9 @@ class PolyData:
                 "values": contour_values,
                 "scalarName": scalar_name_final,
                 "scalarData": scalar_data.flatten().tolist(),
+                # Include mesh geometry for manual contour implementation
+                "points": self.points.flatten().tolist(),
+                "polys": self.faces.flatten().tolist() if self.faces is not None else [],
             },
         )
 

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -43,7 +43,16 @@ type SourceResult =
 async function getPolyData(sourceResult: SourceResult): Promise<VtkPolyData> {
   if (sourceResult.isFilter) {
     await sourceResult.output.update();
-    return sourceResult.output.getOutputData();
+    // Try to get output data if available (not available in VTK.wasm rendering mode)
+    const output = sourceResult.output as {
+      getOutputData?: () => Promise<VtkPolyData>;
+    };
+    if (typeof output.getOutputData === "function") {
+      return await output.getOutputData();
+    }
+    // If getOutputData is not available (rendering mode), return output as-is
+    // Note: This may not have the expected VtkPolyData methods
+    return sourceResult.output as unknown as VtkPolyData;
   }
 
   return sourceResult.output;
@@ -830,13 +839,17 @@ async function applyFilters(
       f.type === "contour" &&
       f.values &&
       f.scalarName &&
-      f.scalarData
+      f.scalarData &&
+      f.points &&
+      f.polys
     ) {
       // eslint-disable-next-line no-await-in-loop -- VTK.wasm requires sequential await
       current = await applyContourFilter(vtk, current, {
         values: f.values,
         scalarName: f.scalarName,
         scalarData: f.scalarData,
+        points: f.points,
+        polys: f.polys,
       });
     }
   }
@@ -992,11 +1005,54 @@ async function applyClipFilter(
  */
 async function applyContourFilter(
   vtk: VtkWasmNamespace,
-  sourceResult: SourceResult,
-  options: { values: number[]; scalarName: string; scalarData: number[] },
+  _sourceResult: SourceResult, // Not used - we create mesh from filter config directly
+  options: {
+    values: number[];
+    scalarName: string;
+    scalarData: number[];
+    points: number[];
+    polys: number[];
+  },
 ): Promise<SourceResult> {
-  const { values, scalarName, scalarData } = options;
-  const inputPd = await getPolyData(sourceResult);
+  const { values, scalarName, scalarData, points, polys } = options;
+
+  // Create PolyData directly from the provided mesh geometry
+  // This avoids the getOutputData() issue in VTK.wasm rendering mode
+  const inputPd = vtk.vtkPolyData();
+  const PointsComponents = 3;
+  const pointsFloatArray = vtk.vtkFloatArray({
+    numberOfComponents: PointsComponents,
+  });
+  await pointsFloatArray.setArray(Float32Array.from(points));
+  const vtkPts = vtk.vtkPoints();
+  await vtkPts.setData(pointsFloatArray);
+  await inputPd.setPoints(vtkPts);
+
+  if (polys && polys.length > 0) {
+    const legacyPolys = polys;
+    const offsetsList: number[] = [0];
+    const connectivityList: number[] = [];
+    let i = 0;
+    while (i < legacyPolys.length) {
+      const count = legacyPolys[i] ?? 0;
+      for (let j = 1; j <= count; j++) {
+        connectivityList.push(legacyPolys[i + j] ?? 0);
+      }
+      offsetsList.push(connectivityList.length);
+      i += count + 1;
+    }
+
+    const ComponentsOne = 1;
+    const offsetsArray = vtk.vtkIntArray({ numberOfComponents: ComponentsOne });
+    await offsetsArray.setArray(Int32Array.from(offsetsList));
+    const connectivityArray = vtk.vtkIntArray({
+      numberOfComponents: ComponentsOne,
+    });
+    await connectivityArray.setArray(Int32Array.from(connectivityList));
+    const cellArray = vtk.vtkCellArray();
+    await cellArray.setData(offsetsArray, connectivityArray);
+    await inputPd.setPolys(cellArray);
+  }
 
   const ComponentsOne = 1;
   const scalars = vtk.vtkFloatArray({

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -1130,7 +1130,7 @@ async function applyContourManual(
   const polysObject = await inputPd.getPolys();
   const polys = await polysObject.getData();
   const pointDataObject = await inputPd.getPointData();
-  const scalarsArray = pointDataObject.getArrayByName(scalarName);
+  const scalarsArray = await pointDataObject.getArrayByName(scalarName);
   if (polys.length === 0 || !scalarsArray) {
     return { output: inputPd, isFilter: false };
   }

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -1001,12 +1001,12 @@ async function applyContourFilter(
   const ComponentsOne = 1;
   const scalars = vtk.vtkFloatArray({
     numberOfComponents: ComponentsOne,
-    values: Float32Array.from(scalarData),
     name: scalarName,
   });
+  await scalars.setArray(Float32Array.from(scalarData));
   const pd = await inputPd.getPointData();
-  pd.addArray(scalars);
-  pd.setActiveScalars(scalarName);
+  await pd.addArray(scalars);
+  await pd.setActiveScalars(scalarName);
 
   return applyContourManual(vtk, inputPd, values, scalarName);
 }
@@ -1024,9 +1024,13 @@ function collectEdgeIntersections(
   inPoints: Float32Array | Uint32Array,
 ): number[] {
   const edgePoints: number[] = [];
+  const Epsilon = 1e-10;
   for (const edge of tri) {
     const [ai, bi, sa, sb] = edge;
-    if ((sa <= value && value < sb) || (sb <= value && value < sa)) {
+    // Use epsilon for floating point comparison
+    const minVal = Math.min(sa, sb) - Epsilon;
+    const maxVal = Math.max(sa, sb) + Epsilon;
+    if (value >= minVal && value <= maxVal && Math.abs(sa - sb) > Epsilon) {
       const t = (value - sa) / (sb - sa);
       edgePoints.push(
         at(inPoints, ai * PointStride + Xoffset) +

--- a/ts/vtk.d.ts
+++ b/ts/vtk.d.ts
@@ -267,6 +267,9 @@ type FilterConfig = {
   values?: number[];
   scalarName?: string;
   scalarData?: number[];
+  // Mesh geometry for contour filter (manual implementation needs raw data)
+  points?: number[];
+  polys?: number[];
 };
 
 /** Configuration for a geometry source (primitive, mesh, or file reader). */


### PR DESCRIPTION
## Summary

Fixes the issue where `PolyData.contour().plot()` shows a white screen in JupyterLite environments.

## Problem

The Examples code at https://pyvista-wasm.readthedocs.io/en/latest/api/_autosummary/pyvista_wasm.PolyData.contour.html would only show a white screen when executed in JupyterLite, without displaying any contour lines.