### PR TITLE
feat: add VTK.wasm configuration options (rendering backend and execution mode)

### DIFF
--- a/src/pyvista_wasm/plotter.py
+++ b/src/pyvista_wasm/plotter.py
@@ -36,6 +36,14 @@ class Plotter:
         Lighting mode for the plotter. Options are:
         - ``"default"`` (default): Creates a default directional light
         - ``None``: No default lights are created, giving full control over lighting
+    wasm_rendering : str, optional
+        WebAssembly rendering backend. One of ``"webgl"`` or ``"webgpu"``.
+        Default is ``"webgl"``.
+    wasm_mode : str, optional
+        Execution mode for VTK.wasm method calls. One of ``"sync"`` or
+        ``"async"``. ``"async"`` requires WebAssembly JavaScript Promise
+        Integration (JSPI) browser support. ``"webgpu"`` rendering always
+        uses ``"async"`` regardless of this setting. Default is ``"sync"``.
 
     Examples
     --------
@@ -54,9 +62,18 @@ class Plotter:
     >>> _ = plotter.add_mesh(mesh, color='white')
     >>> plotter.show()  # doctest: +SKIP
 
+    Create a plotter using WebGPU rendering:
+
+    >>> plotter = pv.Plotter(wasm_rendering='webgpu')  # doctest: +SKIP
+
     """
 
-    def __init__(self, lighting: str | None = "default") -> None:
+    def __init__(
+        self,
+        lighting: str | None = "default",
+        wasm_rendering: str = "webgl",
+        wasm_mode: str = "sync",
+    ) -> None:
         """Initialize a new Plotter instance.
 
         Parameters
@@ -64,10 +81,20 @@ class Plotter:
         lighting : str or None, optional
             Lighting mode. ``"default"`` creates a default directional light,
             ``None`` creates no default lights. Default is ``"default"``.
+        wasm_rendering : str, optional
+            WebAssembly rendering backend. One of ``"webgl"`` or ``"webgpu"``.
+            Default is ``"webgl"``.
+        wasm_mode : str, optional
+            Execution mode for VTK.wasm method calls. One of ``"sync"`` or
+            ``"async"``. Default is ``"sync"``.
 
         """
         self._actors: list[dict[str, object]] = []
-        self._renderer = get_renderer(lighting=lighting)
+        self._renderer = get_renderer(
+            lighting=lighting,
+            wasm_rendering=wasm_rendering,
+            wasm_mode=wasm_mode,
+        )
         self._background_color = (1.0, 1.0, 1.0)  # Default background color
         self._container_id = f"pyvista-container-{uuid.uuid4().hex[:8]}"
         self._camera: Camera | None = None

--- a/src/pyvista_wasm/rendering.py
+++ b/src/pyvista_wasm/rendering.py
@@ -221,7 +221,12 @@ class _BaseHTMLRenderer:
     respective environments (Jupyter notebook, standalone browser, etc.).
     """
 
-    def __init__(self, lighting: str | None = "default") -> None:
+    def __init__(
+        self,
+        lighting: str | None = "default",
+        wasm_rendering: str = "webgl",
+        wasm_mode: str = "sync",
+    ) -> None:
         """Initialize shared renderer state.
 
         Parameters
@@ -229,8 +234,31 @@ class _BaseHTMLRenderer:
         lighting : str or None, optional
             Lighting mode. ``"default"`` creates a default directional light,
             ``None`` creates no default lights. Default is ``"default"``.
+        wasm_rendering : str, optional
+            WebAssembly rendering backend. One of ``"webgl"`` or ``"webgpu"``.
+            Default is ``"webgl"``.
+        wasm_mode : str, optional
+            Execution mode for VTK.wasm method calls. One of ``"sync"`` or
+            ``"async"``. ``"async"`` requires WebAssembly JavaScript Promise
+            Integration (JSPI) browser support. ``"webgpu"`` rendering always
+            uses ``"async"`` regardless of this setting. Default is ``"sync"``.
+
+        Raises
+        ------
+        ValueError
+            If ``wasm_rendering`` is not ``"webgl"`` or ``"webgpu"``, or
+            ``wasm_mode`` is not ``"sync"`` or ``"async"``.
 
         """
+        valid_rendering = {"webgl", "webgpu"}
+        if wasm_rendering not in valid_rendering:
+            msg = f"wasm_rendering must be one of {valid_rendering!r}, got {wasm_rendering!r}"
+            raise ValueError(msg)
+        valid_mode = {"sync", "async"}
+        if wasm_mode not in valid_mode:
+            msg = f"wasm_mode must be one of {valid_mode!r}, got {wasm_mode!r}"
+            raise ValueError(msg)
+
         self.actors: list[dict[str, object]] = []
         self.lights: list[Light] = []
         self.lighting: str | None = lighting
@@ -244,6 +272,8 @@ class _BaseHTMLRenderer:
         self._camera: Camera | None = None
         self._axes_enabled: bool = False
         self._scalar_bar: dict[str, object] | None = None
+        self._wasm_rendering: str = wasm_rendering
+        self._wasm_mode: str = wasm_mode
 
     def create_container(self, element_id: str = "pyvista-container") -> object | None:
         """Store the container ID for later HTML generation.
@@ -760,6 +790,10 @@ class _BaseHTMLRenderer:
             "axes": self._axes_enabled,
             "camera": self._build_camera_data(),
             "lightingMode": self.lighting,
+            "wasmConfig": {
+                "rendering": self._wasm_rendering,
+                "mode": self._wasm_mode,
+            },
         }
 
         # Validate JSON serializable
@@ -773,10 +807,14 @@ class _BaseHTMLRenderer:
 
         scene_data = self._build_scene_data()
         scene_json = _json.dumps(scene_data)
+        wasm_config_json = _json.dumps(
+            {"rendering": self._wasm_rendering, "mode": self._wasm_mode},
+        )
 
         return _jinja_env.from_string(_RENDERING_TEMPLATE).render(
             VTKWASM_UMD=_VTKWASM_UMD,
             VTKWASM_DATA_URL=_VTKWASM_DATA_URL,
+            WASM_CONFIG=wasm_config_json,
             CONTAINER_ID=self.container_id,
             SCENE_JSON=scene_json,
             RENDERER_JS=_RENDERER_JS,
@@ -807,6 +845,9 @@ class _BaseHTMLRenderer:
 
         scene_data = self._build_scene_data()
         scene_json = _json.dumps(scene_data)
+        wasm_config_json = _json.dumps(
+            {"rendering": self._wasm_rendering, "mode": self._wasm_mode},
+        )
 
         # For JupyterLite: pass scene data and container via JS variables
         # so renderer.js can use them directly without DOM lookups.
@@ -831,6 +872,7 @@ class _BaseHTMLRenderer:
             f"    script.src = {_json.dumps(_VTKWASM_UMD)};\n"
             "    script.id = 'vtk-wasm';\n"
             f"    script.dataset.url = {_json.dumps(_VTKWASM_DATA_URL)};\n"
+            f"    script.dataset.config = {_json.dumps(wasm_config_json)};\n"
             "    script.onload = doRender;\n"
             "    document.head.appendChild(script);\n"
             "  }\n"
@@ -940,7 +982,12 @@ class VTKWasmRenderer(_BaseHTMLRenderer):
 
     """
 
-    def __init__(self, lighting: str | None = "default") -> None:
+    def __init__(
+        self,
+        lighting: str | None = "default",
+        wasm_rendering: str = "webgl",
+        wasm_mode: str = "sync",
+    ) -> None:
         """Initialize the VTK.wasm renderer.
 
         Automatically loads VTK.wasm library if in IPython/Jupyter environment.
@@ -950,6 +997,12 @@ class VTKWasmRenderer(_BaseHTMLRenderer):
         lighting : str or None, optional
             Lighting mode. ``"default"`` creates a default directional light,
             ``None`` creates no default lights. Default is ``"default"``.
+        wasm_rendering : str, optional
+            WebAssembly rendering backend. One of ``"webgl"`` or ``"webgpu"``.
+            Default is ``"webgl"``.
+        wasm_mode : str, optional
+            Execution mode for VTK.wasm method calls. One of ``"sync"`` or
+            ``"async"``. Default is ``"sync"``.
 
         Raises
         ------
@@ -963,7 +1016,11 @@ class VTKWasmRenderer(_BaseHTMLRenderer):
             msg = "VTKWasmRenderer requires either Pyodide environment or IPython"
             raise RuntimeError(msg)
 
-        super().__init__(lighting=lighting)
+        super().__init__(
+            lighting=lighting,
+            wasm_rendering=wasm_rendering,
+            wasm_mode=wasm_mode,
+        )
 
         # Automatically load VTK.wasm in IPython/Jupyter (including Pyodide)
         if IPYTHON_AVAILABLE or PYODIDE_ENV:
@@ -1269,7 +1326,12 @@ class MockRenderer:
 
     """
 
-    def __init__(self, lighting: str | None = "default") -> None:
+    def __init__(
+        self,
+        lighting: str | None = "default",
+        wasm_rendering: str = "webgl",
+        wasm_mode: str = "sync",
+    ) -> None:
         """Initialize mock renderer.
 
         Parameters
@@ -1277,6 +1339,10 @@ class MockRenderer:
         lighting : str or None, optional
             Lighting mode. ``"default"`` creates a default directional light,
             ``None`` creates no default lights. Default is ``"default"``.
+        wasm_rendering : str, optional
+            WebAssembly rendering backend (stored but not used). Default is ``"webgl"``.
+        wasm_mode : str, optional
+            Execution mode (stored but not used). Default is ``"sync"``.
 
         """
         self.actors: list[dict[str, object]] = []
@@ -1288,6 +1354,8 @@ class MockRenderer:
         self._view_up: tuple[float, float, float] = (0.0, 1.0, 0.0)
         self._camera: Camera | None = None
         self._scalar_bar: dict[str, object] | None = None
+        self._wasm_rendering: str = wasm_rendering
+        self._wasm_mode: str = wasm_mode
 
     def create_container(self, element_id: str = "pyvista-container") -> None:
         """Mock container creation.
@@ -1657,6 +1725,8 @@ class MockRenderer:
 
 def get_renderer(
     lighting: str | None = "default",
+    wasm_rendering: str = "webgl",
+    wasm_mode: str = "sync",
 ) -> VTKWasmRenderer | BrowserRenderer | MockRenderer:
     """Get appropriate renderer for current environment.
 
@@ -1668,6 +1738,12 @@ def get_renderer(
     lighting : str or None, optional
         Lighting mode. ``"default"`` creates a default directional light,
         ``None`` creates no default lights. Default is ``"default"``.
+    wasm_rendering : str, optional
+        WebAssembly rendering backend. One of ``"webgl"`` or ``"webgpu"``.
+        Default is ``"webgl"``.
+    wasm_mode : str, optional
+        Execution mode for VTK.wasm method calls. One of ``"sync"`` or
+        ``"async"``. Default is ``"sync"``.
 
     Returns
     -------
@@ -1700,8 +1776,20 @@ def get_renderer(
     """
     # Use VTKWasmRenderer if in Pyodide with VTK.wasm OR if IPython is available
     if (PYODIDE_ENV and VTK_AVAILABLE) or IPYTHON_AVAILABLE:
-        return VTKWasmRenderer(lighting=lighting)
+        return VTKWasmRenderer(
+            lighting=lighting,
+            wasm_rendering=wasm_rendering,
+            wasm_mode=wasm_mode,
+        )
     # Respect opt-out env var for CI/testing
     if os.environ.get("PYVISTA_JS_NO_BROWSER"):
-        return MockRenderer(lighting=lighting)
-    return BrowserRenderer(lighting=lighting)
+        return MockRenderer(
+            lighting=lighting,
+            wasm_rendering=wasm_rendering,
+            wasm_mode=wasm_mode,
+        )
+    return BrowserRenderer(
+        lighting=lighting,
+        wasm_rendering=wasm_rendering,
+        wasm_mode=wasm_mode,
+    )

--- a/src/pyvista_wasm/templates/standalone.html
+++ b/src/pyvista_wasm/templates/standalone.html
@@ -2,6 +2,7 @@
   src="{{ VTKWASM_UMD }}"
   id="vtk-wasm"
   data-url="{{ VTKWASM_DATA_URL }}"
+  data-config="{{ WASM_CONFIG }}"
 ></script>
 <div id="{{ CONTAINER_ID }}"
      style="width: 600px;

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1325,3 +1325,29 @@ def test_add_mesh_with_smooth_shading_disabled() -> None:
 
     assert len(plotter.actors) == 1
     assert plotter.actors[0]["smooth_shading"] is False
+
+
+def test_plotter_wasm_config_defaults() -> None:
+    """Test that Plotter creates renderer with default wasm config."""
+    plotter = Plotter()
+    assert plotter._renderer._wasm_rendering == "webgl"
+    assert plotter._renderer._wasm_mode == "sync"
+
+
+def test_plotter_wasm_config_webgpu() -> None:
+    """Test that Plotter passes wasm config to renderer."""
+    plotter = Plotter(wasm_rendering="webgpu", wasm_mode="async")
+    assert plotter._renderer._wasm_rendering == "webgpu"
+    assert plotter._renderer._wasm_mode == "async"
+
+
+def test_plotter_wasm_config_invalid_rendering() -> None:
+    """Test that Plotter raises ValueError for invalid wasm_rendering."""
+    with pytest.raises(ValueError, match="wasm_rendering"):
+        Plotter(wasm_rendering="opengl")
+
+
+def test_plotter_wasm_config_invalid_mode() -> None:
+    """Test that Plotter raises ValueError for invalid wasm_mode."""
+    with pytest.raises(ValueError, match="wasm_mode"):
+        Plotter(wasm_mode="parallel")

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -531,3 +531,84 @@ def test_smooth_shading_with_actor_index(monkeypatch) -> None:
     # Second actor (Cube with smooth_shading=False): flat shading
     actor1 = scene["actors"][1]
     assert actor1["shading"] == "flat"
+
+
+def test_wasm_config_defaults_in_scene_data(monkeypatch) -> None:
+    """Test that default wasm config is included in scene data."""
+    from tests.conftest import extract_scene_data  # noqa: PLC0415
+
+    monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", True)
+    renderer = rendering.VTKWasmRenderer()
+    renderer.add_mesh_actor(Sphere(), color="red")
+
+    html = renderer._repr_html_()
+    scene = extract_scene_data(html)
+
+    assert "wasmConfig" in scene
+    assert scene["wasmConfig"]["rendering"] == "webgl"
+    assert scene["wasmConfig"]["mode"] == "sync"
+
+
+def test_wasm_config_webgpu_in_scene_data(monkeypatch) -> None:
+    """Test that webgpu config is included in scene data."""
+    from tests.conftest import extract_scene_data  # noqa: PLC0415
+
+    monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", True)
+    renderer = rendering.VTKWasmRenderer(wasm_rendering="webgpu", wasm_mode="async")
+    renderer.add_mesh_actor(Sphere(), color="red")
+
+    html = renderer._repr_html_()
+    scene = extract_scene_data(html)
+
+    assert scene["wasmConfig"]["rendering"] == "webgpu"
+    assert scene["wasmConfig"]["mode"] == "async"
+
+
+def test_wasm_config_in_standalone_html(monkeypatch) -> None:
+    """Test that data-config attribute is present in standalone HTML."""
+    monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", True)
+    renderer = rendering.VTKWasmRenderer(wasm_rendering="webgpu")
+    renderer.add_mesh_actor(Sphere(), color="red")
+
+    html = renderer.generate_standalone_html()
+
+    assert 'data-config="' in html
+    assert '"rendering": "webgpu"' in html
+
+
+def test_wasm_config_in_render_js(monkeypatch) -> None:
+    """Test that data-config is set on script element in generated JS."""
+    monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", True)
+    renderer = rendering.VTKWasmRenderer(wasm_rendering="webgpu", wasm_mode="async")
+    renderer.add_mesh_actor(Sphere(), color="red")
+
+    js = renderer._generate_render_js()
+
+    assert "script.dataset.config" in js
+    assert "webgpu" in js
+
+
+def test_wasm_config_invalid_rendering() -> None:
+    """Test that invalid wasm_rendering raises ValueError."""
+    with pytest.raises(ValueError, match="wasm_rendering"):
+        rendering.BrowserRenderer(wasm_rendering="invalid")
+
+
+def test_wasm_config_invalid_mode() -> None:
+    """Test that invalid wasm_mode raises ValueError."""
+    with pytest.raises(ValueError, match="wasm_mode"):
+        rendering.BrowserRenderer(wasm_mode="invalid")
+
+
+def test_wasm_config_browser_renderer() -> None:
+    """Test that BrowserRenderer stores wasm config."""
+    renderer = rendering.BrowserRenderer(wasm_rendering="webgpu", wasm_mode="async")
+    assert renderer._wasm_rendering == "webgpu"
+    assert renderer._wasm_mode == "async"
+
+
+def test_mock_renderer_stores_wasm_config() -> None:
+    """Test that MockRenderer stores wasm config."""
+    renderer = rendering.MockRenderer(wasm_rendering="webgpu", wasm_mode="async")
+    assert renderer._wasm_rendering == "webgpu"
+    assert renderer._wasm_mode == "async"

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -334,7 +334,7 @@ if (typeof vtkReady !== "undefined") {
   ); // eslint-disable-line unicorn/prefer-top-level-await
 } else if (typeof vtkWASM !== "undefined") {
   void vtkWASM
-    .createNamespace()
+    .createNamespace(undefined, pvSceneData.wasmConfig)
     .then((vtk) => buildScene(vtk, pvOverlay, pvContainer, pvSceneData)); // eslint-disable-line unicorn/prefer-top-level-await
 }
 

--- a/ts/vtk.d.ts
+++ b/ts/vtk.d.ts
@@ -352,6 +352,12 @@ type TextActorConfig = {
   italic: boolean;
 };
 
+/** VTK.wasm configuration options for createNamespace(). */
+type WasmConfig = {
+  rendering?: "webgl" | "webgpu";
+  mode?: "sync" | "async";
+};
+
 /** Top-level scene description passed from Python as JSON. */
 type SceneData = {
   containerId: string;
@@ -362,6 +368,7 @@ type SceneData = {
   textActors?: TextActorConfig[];
   axes: boolean;
   camera?: CameraConfig;
+  wasmConfig?: WasmConfig;
 };
 
 declare const __pvwasmSceneData: SceneData | undefined;
@@ -375,7 +382,7 @@ declare const __pvwasmContainer: HTMLElement | undefined;
 declare const vtkWASM: {
   createNamespace: (
     url?: string,
-    config?: { rendering?: string; mode?: string },
+    config?: WasmConfig,
   ) => Promise<VtkWasmNamespace>;
 };
 


### PR DESCRIPTION
## Summary

Add support for the `createNamespace(url, config)` configuration options from [VTK.wasm](https://kitware.github.io/vtk-wasm/guide/js/plain.html#configuration-options), allowing users to choose between WebGL/WebGPU rendering backends and sync/async execution modes.

## Usage

```python
import pyvista_wasm as pv

# Default: WebGL + synchronous
plotter = pv.Plotter()

# WebGPU rendering (requires JSPI-capable browser)
plotter = pv.Plotter(wasm_rendering='webgpu')

# WebGL with async execution
plotter = pv.Plotter(wasm_rendering='webgl', wasm_mode='async')
```

## Configuration Options

| Option | Values | Default | Description |
|--------|--------|---------|-------------|
| `wasm_rendering` | `"webgl"`, `"webgpu"` | `"webgl"` | Rendering backend |
| `wasm_mode` | `"sync"`, `"async"` | `"sync"` | Method execution mode (`"async"` requires JSPI) |

> **Note:** WebGPU rendering always uses async mode regardless of the `wasm_mode` setting.

## Reference

https://kitware.github.io/vtk-wasm/guide/js/plain.html#configuration-options