### PR TITLE
feat: mirror VTK.wasm binary to npm and serve via jsDelivr CDN

### DIFF
--- a/.github/workflows/check-vtk-wasm-update.yml
+++ b/.github/workflows/check-vtk-wasm-update.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   check:
     runs-on: ubuntu-latest
+    environment: release-please
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/check-vtk-wasm-update.yml
+++ b/.github/workflows/check-vtk-wasm-update.yml
@@ -1,0 +1,93 @@
+name: Check VTK.wasm Update
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 09:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: true
+
+      - name: Get current version
+        id: current
+        run: |
+          version=$(node -p "require('./packages/vtk-wasm-binary/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Current version: $version"
+
+      - name: Get latest upstream version
+        id: latest
+        run: |
+          version=$(curl -sf "https://gitlab.kitware.com/api/v4/projects/13/packages?package_name=vtk-wasm32-emscripten&sort=desc&per_page=1" | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'))[0].version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Latest upstream version: $version"
+
+      - name: Compare versions
+        id: compare
+        env:
+          CURRENT: ${{ steps.current.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+        run: |
+          if [ "$CURRENT" = "$LATEST" ]; then
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+            echo "Already up to date ($CURRENT)"
+          else
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
+            echo "Update available: $CURRENT -> $LATEST"
+          fi
+
+      - name: Update version references
+        if: steps.compare.outputs.needs_update == 'true'
+        env:
+          CURRENT: ${{ steps.current.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+        run: |
+          # Update npm package version
+          cd packages/vtk-wasm-binary
+          npm version "$LATEST" --no-git-tag-version
+          cd ../..
+
+          # Update rendering.py
+          sed -i "s/_VTKWASM_VERSION = \"${CURRENT}\"/_VTKWASM_VERSION = \"${LATEST}\"/" src/pyvista_wasm/rendering.py
+
+          # Update streamlit.html
+          sed -i "s/vtk-wasm-binary@${CURRENT}/vtk-wasm-binary@${LATEST}/g" src/pyvista_wasm/templates/streamlit.html
+
+          # Update docstring example URL
+          sed -i "s/vtk-wasm-binary@${CURRENT}/vtk-wasm-binary@${LATEST}/g" src/pyvista_wasm/rendering.py
+
+          echo "Updated all references from $CURRENT to $LATEST"
+
+      - name: Create pull request
+        if: steps.compare.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST: ${{ steps.latest.outputs.version }}
+          CURRENT: ${{ steps.current.outputs.version }}
+        run: |
+          branch="update-vtk-wasm-${LATEST}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "chore: update VTK.wasm binary to ${LATEST}"
+          git push origin "$branch"
+          gh pr create \
+            --title "chore: update VTK.wasm binary to ${LATEST}" \
+            --body "Update VTK.wasm binary from \`${CURRENT}\` to \`${LATEST}\`.
+
+          Detected by the [check-vtk-wasm-update](${{ github.server_url }}/${{ github.repository }}/actions/workflows/check-vtk-wasm-update.yml) workflow.
+
+          Once merged, the [mirror-vtk-wasm](${{ github.server_url }}/${{ github.repository }}/actions/workflows/mirror-vtk-wasm.yml) workflow will automatically publish the new binary to npm." \
+            --head "$branch" \
+            --base main

--- a/.github/workflows/check-vtk-wasm-update.yml
+++ b/.github/workflows/check-vtk-wasm-update.yml
@@ -71,13 +71,13 @@ jobs:
       - name: Create pull request
         if: steps.compare.outputs.needs_update == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           LATEST: ${{ steps.latest.outputs.version }}
           CURRENT: ${{ steps.current.outputs.version }}
         run: |
           branch="update-vtk-wasm-${LATEST}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Tetsuo Koyama"
+          git config user.email "tkoyama010@users.noreply.github.com"
           git checkout -b "$branch"
           git add -A
           git commit -m "chore: update VTK.wasm binary to ${LATEST}"

--- a/.github/workflows/mirror-vtk-wasm.yml
+++ b/.github/workflows/mirror-vtk-wasm.yml
@@ -37,15 +37,16 @@ jobs:
       - name: Check if already published
         id: check
         working-directory: packages/vtk-wasm-binary
+        env:
+          VTK_VERSION: ${{ steps.version.outputs.version }}
         run: |
           pkg=$(node -p "require('./package.json').name")
-          version="${{ steps.version.outputs.version }}"
-          if npm view "${pkg}@${version}" version 2>/dev/null; then
+          if npm view "${pkg}@${VTK_VERSION}" version 2>/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "${pkg}@${version} already published, skipping."
+            echo "${pkg}@${VTK_VERSION} already published, skipping."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "${pkg}@${version} not found, will publish."
+            echo "${pkg}@${VTK_VERSION} not found, will publish."
           fi
 
       - name: Download WASM binary from upstream

--- a/.github/workflows/mirror-vtk-wasm.yml
+++ b/.github/workflows/mirror-vtk-wasm.yml
@@ -72,6 +72,4 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.exists == 'false'
         working-directory: packages/vtk-wasm-binary
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
+        run: npm publish --access public

--- a/.github/workflows/mirror-vtk-wasm.yml
+++ b/.github/workflows/mirror-vtk-wasm.yml
@@ -1,0 +1,77 @@
+name: Mirror VTK.wasm Binary
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/vtk-wasm-binary/package.json"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Extract version
+        id: version
+        working-directory: packages/vtk-wasm-binary
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "VTK.wasm version: $version"
+
+      - name: Check if already published
+        id: check
+        working-directory: packages/vtk-wasm-binary
+        run: |
+          pkg=$(node -p "require('./package.json').name")
+          version="${{ steps.version.outputs.version }}"
+          if npm view "${pkg}@${version}" version 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "${pkg}@${version} already published, skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "${pkg}@${version} not found, will publish."
+          fi
+
+      - name: Download WASM binary from upstream
+        if: steps.check.outputs.exists == 'false'
+        working-directory: packages/vtk-wasm-binary
+        run: node download.mjs
+
+      - name: Verify downloaded file
+        if: steps.check.outputs.exists == 'false'
+        working-directory: packages/vtk-wasm-binary
+        run: |
+          file="vtk-wasm32-emscripten.tar.gz"
+          if [ ! -f "$file" ]; then
+            echo "::error::Download failed — $file not found"
+            exit 1
+          fi
+          size=$(stat --format=%s "$file")
+          echo "File size: $((size / 1024 / 1024)) MB"
+          if [ "$size" -lt 1000000 ]; then
+            echo "::error::File is suspiciously small ($size bytes)"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.exists == 'false'
+        working-directory: packages/vtk-wasm-binary
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ jupyterlite/content/*.ipynb
 # Preview GIFs (stored in GitHub Releases, not in the repo)
 assets/*.gif
 
+# Environment variables
+.envrc
+
 # Node.js (TypeScript build)
 node_modules/
 src/pyvista_wasm/templates/renderer.js

--- a/packages/vtk-wasm-binary/README.md
+++ b/packages/vtk-wasm-binary/README.md
@@ -13,8 +13,8 @@ https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@<version>/vtk-wasm32-
 ## Updating
 
 1. Update the `version` in `package.json` to match the upstream VTK.wasm version.
-2. Run `npm run download` to fetch the binary from upstream.
-3. Publish with `npm publish`.
+1. Run `npm run download` to fetch the binary from upstream.
+1. Publish with `npm publish`.
 
 The [mirror-vtk-wasm](.github/workflows/mirror-vtk-wasm.yml) workflow automates
 steps 2 and 3.

--- a/packages/vtk-wasm-binary/README.md
+++ b/packages/vtk-wasm-binary/README.md
@@ -1,0 +1,20 @@
+# @pyvista-wasm/vtk-wasm-binary
+
+Mirrored VTK.wasm binary for pyvista-wasm, served via [jsDelivr](https://www.jsdelivr.com/) CDN.
+
+## Usage
+
+The binary is available at:
+
+```
+https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@<version>/vtk-wasm32-emscripten.tar.gz
+```
+
+## Updating
+
+1. Update the `version` in `package.json` to match the upstream VTK.wasm version.
+2. Run `npm run download` to fetch the binary from upstream.
+3. Publish with `npm publish`.
+
+The [mirror-vtk-wasm](.github/workflows/mirror-vtk-wasm.yml) workflow automates
+steps 2 and 3.

--- a/packages/vtk-wasm-binary/download.mjs
+++ b/packages/vtk-wasm-binary/download.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/**
+ * Download the VTK.wasm binary from upstream Kitware GitLab.
+ *
+ * Usage:
+ *   node download.mjs [version]
+ *
+ * If no version is given, it reads the version from package.json.
+ */
+
+import { createWriteStream } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const pkg = JSON.parse(
+  await readFile(join(__dirname, "package.json"), "utf8"),
+);
+const version = process.argv[2] || pkg.version;
+
+const url =
+  `https://gitlab.kitware.com/api/v4/projects/13/packages/generic/` +
+  `vtk-wasm32-emscripten/${version}/vtk-${version}-wasm32-emscripten.tar.gz`;
+
+const outPath = join(__dirname, "vtk-wasm32-emscripten.tar.gz");
+
+console.log(`Downloading VTK.wasm ${version}...`);
+console.log(`  Source: ${url}`);
+
+const res = await fetch(url, { redirect: "follow" });
+if (!res.ok) {
+  console.error(`Download failed: ${res.status} ${res.statusText}`);
+  process.exit(1);
+}
+
+await pipeline(res.body, createWriteStream(outPath));
+
+console.log(`  Saved to: ${outPath}`);

--- a/packages/vtk-wasm-binary/package.json
+++ b/packages/vtk-wasm-binary/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@pyvista-wasm/vtk-wasm-binary",
+  "version": "9.6.20260228",
+  "description": "Mirrored VTK.wasm binary for pyvista-wasm (served via jsDelivr CDN)",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tkoyama010/pyvista-wasm.git",
+    "directory": "packages/vtk-wasm-binary"
+  },
+  "files": [
+    "vtk-wasm32-emscripten.tar.gz"
+  ],
+  "scripts": {
+    "download": "node download.mjs"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/src/pyvista_wasm/rendering.py
+++ b/src/pyvista_wasm/rendering.py
@@ -46,7 +46,7 @@ For manual loading or custom versions:
     <script
       src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
       id="vtk-wasm"
-      data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz"
+      data-url="https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@9.6.20260228/vtk-wasm32-emscripten.tar.gz"
     ></script>
 
 Examples
@@ -105,9 +105,10 @@ _jinja_env = Environment(undefined=StrictUndefined, autoescape=False)  # noqa: S
 
 # VTK.wasm CDN URLs used across renderers
 _VTKWASM_UMD = "https://unpkg.com/@kitware/vtk-wasm@1.7.4/vtk-umd.js"
+_VTKWASM_VERSION = "9.6.20260228"
 _VTKWASM_DATA_URL = (
-    "https://gitlab.kitware.com/api/v4/projects/13/packages/generic/"
-    "vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz"
+    "https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary"
+    f"@{_VTKWASM_VERSION}/vtk-wasm32-emscripten.tar.gz"
 )
 
 # Check if running in Pyodide environment

--- a/src/pyvista_wasm/templates/streamlit.html
+++ b/src/pyvista_wasm/templates/streamlit.html
@@ -22,7 +22,7 @@
         <script
           src="https://unpkg.com/@kitware/vtk-wasm@1.7.4/vtk-umd.js"
           id="vtk-wasm"
-          data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz"
+          data-url="https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@9.6.20260228/vtk-wasm32-emscripten.tar.gz"
         ></script>
     </head>
     <body>


### PR DESCRIPTION
## Summary

Replace the GitLab Package Registry URL for the VTK.wasm binary with a jsDelivr CDN URL backed by the new `@pyvista-wasm/vtk-wasm-binary` npm package.

## Motivation

The current `data-url` for the VTK.wasm binary points to Kitware's self-hosted GitLab API endpoint (`gitlab.kitware.com/api/v4/...`), which has limited CDN infrastructure and can be slow, especially for users in Asia.

jsDelivr's multi-CDN architecture (Cloudflare + Fastly + Bunny CDN) provides:
- **Faster delivery** via globally distributed edge servers
- **Higher availability** through automatic CDN failover
- **Better caching** with optimized cache headers