### PR TITLE
fix: escape WASM_CONFIG JSON in standalone.html data-config attribute

### DIFF
--- a/src/pyvista_wasm/templates/standalone.html
+++ b/src/pyvista_wasm/templates/standalone.html
@@ -2,7 +2,7 @@
   src="{{ VTKWASM_UMD }}"
   id="vtk-wasm"
   data-url="{{ VTKWASM_DATA_URL }}"
-  data-config="{{ WASM_CONFIG }}"
+  data-config='{{ WASM_CONFIG }}'
 ></script>
 <div id="{{ CONTAINER_ID }}"
      style="width: 600px;

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -572,7 +572,7 @@ def test_wasm_config_in_standalone_html(monkeypatch) -> None:
 
     html = renderer.generate_standalone_html()
 
-    assert 'data-config="' in html
+    assert "data-config='" in html
     assert '"rendering": "webgpu"' in html
 
 


### PR DESCRIPTION
## Summary

- `standalone.html` had `data-config` wrapped in double-quotes, which conflicted with the double-quotes inside the JSON value
- The HTML parser truncated the attribute value at the first inner `"`, leaving `B.dataset.config` as `{`
- `JSON.parse("{")` threw a `SyntaxError` before `window.vtkReady` could be assigned, causing the stlite iframe to hang forever on "Initializing WASM Environment…"

## Root Cause

`vtk.umd.js` runs this on startup:

```javascript
const B = document.querySelector("#vtk-wasm");
if (B) {
    const t = JSON.parse(B.dataset.config || "{}");  // SyntaxError here
    window.vtkReady = ve, ...
}
```

The malformed HTML `data-config="{"rendering": "webgl", "mode": "sync"}"` caused `B.dataset.config` to be just `{`.

## Fix

Switch `data-config` to single-quotes so the JSON value is preserved intact:

```html
- data-config="{{ WASM_CONFIG }}"
+ data-config='{{ WASM_CONFIG }}'
```

## Test plan

- [ ] Confirm "Initializing WASM Environment…" is resolved in the stlite demo
- [ ] Confirm JupyterLite rendering is unaffected