### PR TITLE
docs: add AGENTS.md and CLAUDE.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ No local setup is required. CI verifies the dev environment on every PR.
 
 ## Testing instructions
 
-CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) automatically runs linting and formatting checks. Keep fixing and pushing until all CI checks pass.
+CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) automatically runs linting and formatting checks. [Read the Docs](https://readthedocs.org) builds a documentation preview for every PR. Keep fixing and pushing until all CI checks pass.
 
 ## PR instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ No local setup is required. CI verifies the dev environment on every PR.
 
 ## Testing instructions
 
-No local test runs are required. CI runs the full test suite on every PR.
+CI runs the full test suite on every PR. Keep fixing and pushing until all CI checks pass.
 
 ## PR instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ No local setup is required. CI verifies the dev environment on every PR.
 
 ## Testing instructions
 
-CI runs the full test suite on every PR. Keep fixing and pushing until all CI checks pass.
+CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) automatically runs linting and formatting checks. Keep fixing and pushing until all CI checks pass.
 
 ## PR instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,6 @@ uv run pytest --cov=pyvista_wasm    # with coverage
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
 - Write commit messages and PR descriptions to explain **why**, not what. The diff shows what changed; the message should explain the motivation.
+- Do not add AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) to commit messages or PR descriptions.
 - Run `uv run pre-commit run --all-files` before opening a PR.
 - Do not edit `src/pyvista_wasm/templates/renderer.js` directly — it is a generated build artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,6 @@ uv run pytest --cov=pyvista_wasm    # with coverage
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
 - Write commit messages and PR descriptions to explain **why**, not what. The diff shows what changed; the message should explain the motivation.
-- Do not add AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) to commit messages or PR descriptions.
+- Remove AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) from commit messages and PR descriptions.
 - Run `uv run pre-commit run --all-files` before opening a PR.
-- Do not edit `src/pyvista_wasm/templates/renderer.js` directly — it is a generated build artifact.
+- Ignore `src/pyvista_wasm/templates/renderer.js` — it is a generated build artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,16 @@
 # AGENTS.md
 
-## Dev environment
+## Dev environment tips
 
-```bash
-uv sync --group dev
-uv run pre-commit install
-uv run playwright install chromium
-npm install  # only when editing TypeScript files
-npm run build  # regenerate src/pyvista_wasm/templates/renderer.js after TS edits
-```
+No local setup is required. CI verifies the dev environment on every PR.
 
-## Testing
+## Testing instructions
 
-```bash
-uv run pytest -m "not playwright"   # standard test run
-uv run tox -e py312                 # test against a specific Python version
-uv run pytest --cov=pyvista_wasm    # with coverage
-```
+No local test runs are required. CI runs the full test suite on every PR.
 
 ## PR instructions
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
 - Write commit messages and PR descriptions to explain **why**, not what. The diff shows what changed; the message should explain the motivation.
 - Remove AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) from commit messages and PR descriptions.
-- Run `uv run pre-commit run --all-files` before opening a PR.
 - Ignore `src/pyvista_wasm/templates/renderer.js` — it is a generated build artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Dev environment
+
+```bash
+uv sync --group dev
+uv run pre-commit install
+uv run playwright install chromium
+npm install  # only when editing TypeScript files
+npm run build  # regenerate src/pyvista_wasm/templates/renderer.js after TS edits
+```
+
+## Testing
+
+```bash
+uv run pytest -m "not playwright"   # standard test run
+uv run tox -e py312                 # test against a specific Python version
+uv run pytest --cov=pyvista_wasm    # with coverage
+```
+
+## PR instructions
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
+- Run `uv run pre-commit run --all-files` before opening a PR.
+- Do not edit `src/pyvista_wasm/templates/renderer.js` directly — it is a generated build artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,6 @@ uv run pytest --cov=pyvista_wasm    # with coverage
 ## PR instructions
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
+- Write commit messages and PR descriptions to explain **why**, not what. The diff shows what changed; the message should explain the motivation.
 - Run `uv run pre-commit run --all-files` before opening a PR.
 - Do not edit `src/pyvista_wasm/templates/renderer.js` directly — it is a generated build artifact.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
AI coding agents benefit from a dedicated, predictable place to find project context. This adds `AGENTS.md` following the [agents.md](https://github.com/agentsmd/agents.md) convention, and `CLAUDE.md` that references it via `@AGENTS.md` so Claude Code picks it up automatically.