### PR TITLE
docs: clarify PR instructions for commit message content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,4 +15,3 @@ CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) 
 - Remove descriptions of **what** changed from commit messages and PR descriptions. The diff shows what changed; the message should explain the motivation.
 - Remove test information from commit messages and PR descriptions. The diff shows test code, and CI shows test results.
 - Remove AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) from commit messages and PR descriptions.
-- Ignore `src/pyvista_wasm/templates/renderer.js` �it is a generated build artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) 
 ## PR instructions
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
-- Write commit messages and PR descriptions to explain **why**, not what. The diff shows what changed; the message should explain the motivation.
+- Write commit messages and PR descriptions to explain **why**.
+- Remove descriptions of **what** changed from commit messages and PR descriptions. The diff shows what changed; the message should explain the motivation.
+- Remove test information from commit messages and PR descriptions. The diff shows test code.
 - Remove AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) from commit messages and PR descriptions.
-- Ignore `src/pyvista_wasm/templates/renderer.js` — it is a generated build artifact.
+- Ignore `src/pyvista_wasm/templates/renderer.js` �it is a generated build artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) 
 ## PR instructions
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
-- Write commit messages and PR descriptions to explain **why**.
-- Remove descriptions of **what** changed from commit messages and PR descriptions. The diff shows what changed; the message should explain the motivation.
+- Write commit messages and PR descriptions to explain **why**; the message and descriptions should explain the motivation.
+- Remove descriptions of **what** changed from commit messages and PR descriptions. The diff shows what changed.
 - Remove test information from commit messages and PR descriptions. The diff shows test code, and CI shows test results.
 - Remove AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) from commit messages and PR descriptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,6 @@ CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) 
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
 - Write commit messages and PR descriptions to explain **why**; the message and descriptions should explain the motivation.
-- Remove descriptions of **what** changed from commit messages and PR descriptions. The diff shows what changed.
-- Remove test information from commit messages and PR descriptions. The diff shows test code, and CI shows test results.
+- Remove commit messages and PR descriptions to explain **what**; the diff shows what changed.
+- Remove commit messages and PR descriptions to explain **test information**; the diff shows test code, and CI shows test results.
 - Remove AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) from commit messages and PR descriptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,6 @@ CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
 - Write commit messages and PR descriptions to explain **why**.
 - Remove descriptions of **what** changed from commit messages and PR descriptions. The diff shows what changed; the message should explain the motivation.
-- Remove test information from commit messages and PR descriptions. The diff shows test code.
+- Remove test information from commit messages and PR descriptions. The diff shows test code, and CI shows test results.
 - Remove AI coding agent co-author lines (e.g. `Co-Authored-By: Claude`) from commit messages and PR descriptions.
 - Ignore `src/pyvista_wasm/templates/renderer.js` �it is a generated build artifact.


### PR DESCRIPTION
## Summary

- Split the single "explain why, not what" rule into explicit rules to reduce ambiguity for AI coding agents
- Agents were including redundant "what" descriptions, test details, and test plans in commit messages and PR descriptions; explicit rules for each case prevent this