### PR TITLE
docs: instruct agents to monitor CI after creating a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,10 @@ No local setup is required. CI verifies the dev environment on every PR.
 
 ## Testing instructions
 
-CI runs the full test suite on every PR. [pre-commit.ci](https://pre-commit.ci) automatically runs linting and formatting checks. [Read the Docs](https://readthedocs.org) builds a documentation preview for every PR. Keep fixing and pushing until all CI checks pass.
+- CI runs the full test suite on every PR. 
+- [pre-commit.ci](https://pre-commit.ci) automatically runs linting and formatting checks. 
+- [Read the Docs](https://readthedocs.org) builds a documentation preview for every PR. 
+- After creating a PR, monitor CI continuously, keep fixing and pushing until all checks pass.
 
 ## PR instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@ No local setup is required. CI verifies the dev environment on every PR.
 
 ## Testing instructions
 
-- CI runs the full test suite on every PR. 
-- [pre-commit.ci](https://pre-commit.ci) automatically runs linting and formatting checks. 
-- [Read the Docs](https://readthedocs.org) builds a documentation preview for every PR. 
+- CI runs the full test suite on every PR.
+- [pre-commit.ci](https://pre-commit.ci) automatically runs linting and formatting checks.
+- [Read the Docs](https://readthedocs.org) builds a documentation preview for every PR.
 - After creating a PR, monitor CI continuously, keep fixing and pushing until all checks pass.
 
 ## PR instructions


### PR DESCRIPTION
## Summary

- Merged the two separate testing instructions ("Keep fixing and pushing" and CI monitoring) into a single, clearer directive
- Agents are now explicitly told to monitor CI continuously after opening a PR and keep iterating until all checks pass