### PR TITLE
fix: always normalize screenshot channels when creating GIF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
   { include-group = "test" },
 ]
 test = [
+  "imageio>=2.28.0,<2.38.0",
   "pillow>=9.0.0,<13.0.0",
   "playwright>=1.40.0,<1.50.0",
   "pytest>=7.0.0,<9.1.0",

--- a/src/pyvista_wasm/_cli.py
+++ b/src/pyvista_wasm/_cli.py
@@ -732,23 +732,19 @@ def _create_gif(screenshots_dir: Path, output_path: Path, fps: int = 2) -> bool:
         logger.error("No screenshots found!")
         return False
 
+    import numpy as np  # noqa: PLC0415
+    from PIL import Image  # noqa: PLC0415
+
     logger.info("Found %d screenshots", len(screenshot_files))
-    images = [iio.imread(f) for f in screenshot_files]
+    raw_images = [iio.imread(f) for f in screenshot_files]
 
-    target_shape = images[0].shape[:2]
-    if any(img.shape[:2] != target_shape for img in images):
-        import numpy as np  # noqa: PLC0415
-        from PIL import Image  # noqa: PLC0415
-
-        resized = []
-        for img in images:
-            pil_img = Image.fromarray(img)
-            pil_img = pil_img.resize(
-                (target_shape[1], target_shape[0]),
-                Image.LANCZOS,
-            )
-            resized.append(np.array(pil_img))
-        images = resized
+    target_size = (raw_images[0].shape[1], raw_images[0].shape[0])  # (width, height)
+    images = []
+    for img in raw_images:
+        pil_img = Image.fromarray(img).convert("RGB")
+        if pil_img.size != target_size:
+            pil_img = pil_img.resize(target_size, Image.LANCZOS)
+        images.append(np.array(pil_img))
 
     duration_ms = int(1000 / fps)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/pyvista_wasm/_cli.py
+++ b/src/pyvista_wasm/_cli.py
@@ -735,6 +735,20 @@ def _create_gif(screenshots_dir: Path, output_path: Path, fps: int = 2) -> bool:
     logger.info("Found %d screenshots", len(screenshot_files))
     images = [iio.imread(f) for f in screenshot_files]
 
+    target_shape = images[0].shape[:2]
+    if any(img.shape[:2] != target_shape for img in images):
+        import numpy as np  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+
+        resized = []
+        for img in images:
+            pil_img = Image.fromarray(img)
+            pil_img = pil_img.resize(
+                (target_shape[1], target_shape[0]), Image.LANCZOS
+            )
+            resized.append(np.array(pil_img))
+        images = resized
+
     duration_ms = int(1000 / fps)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/pyvista_wasm/_cli.py
+++ b/src/pyvista_wasm/_cli.py
@@ -744,7 +744,8 @@ def _create_gif(screenshots_dir: Path, output_path: Path, fps: int = 2) -> bool:
         for img in images:
             pil_img = Image.fromarray(img)
             pil_img = pil_img.resize(
-                (target_shape[1], target_shape[0]), Image.LANCZOS
+                (target_shape[1], target_shape[0]),
+                Image.LANCZOS,
             )
             resized.append(np.array(pil_img))
         images = resized

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -845,7 +845,9 @@ class TestCreateGif:
     def test_uniform_rgb(self, tmp_path) -> None:
         """_create_gif creates a GIF from uniformly-shaped RGB screenshots."""
         for i in range(1, 4):
-            _write_png(tmp_path / f"screenshot_{i:02d}.png", np.zeros((100, 100, 3), dtype=np.uint8))
+            _write_png(
+                tmp_path / f"screenshot_{i:02d}.png", np.zeros((100, 100, 3), dtype=np.uint8)
+            )
 
         assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
         assert (tmp_path / "out.gif").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -834,11 +834,6 @@ def test_plot_new_plotter_with_camera_movement() -> None:
         cli_main(["plot", str(VTK_FILE), "--azimuth", "45", "--zoom", "1.5"])
 
 
-# ---------------------------------------------------------------------------
-# _create_gif
-# ---------------------------------------------------------------------------
-
-
 def _write_png(path: Path, array: np.ndarray) -> None:
     """Save a numpy array as a PNG file."""
     from PIL import Image  # noqa: PLC0415
@@ -846,160 +841,142 @@ def _write_png(path: Path, array: np.ndarray) -> None:
     Image.fromarray(array).save(path)
 
 
-def test_create_gif_uniform_rgb(tmp_path) -> None:
-    """_create_gif creates a GIF from uniformly-shaped RGB screenshots."""
-    for i in range(1, 4):
-        _write_png(tmp_path / f"screenshot_{i:02d}.png", np.zeros((100, 100, 3), dtype=np.uint8))
+class TestCreateGif:
+    def test_uniform_rgb(self, tmp_path) -> None:
+        """_create_gif creates a GIF from uniformly-shaped RGB screenshots."""
+        for i in range(1, 4):
+            _write_png(tmp_path / f"screenshot_{i:02d}.png", np.zeros((100, 100, 3), dtype=np.uint8))
 
-    assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
-    assert (tmp_path / "out.gif").exists()
+        assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
+        assert (tmp_path / "out.gif").exists()
 
+    def test_mixed_channels(self, tmp_path) -> None:
+        """_create_gif handles screenshots with mixed channel counts (RGB and RGBA)."""
+        _write_png(tmp_path / "screenshot_01.png", np.zeros((100, 100, 3), dtype=np.uint8))
+        _write_png(tmp_path / "screenshot_02.png", np.zeros((100, 100, 4), dtype=np.uint8))
+        _write_png(tmp_path / "screenshot_03.png", np.zeros((100, 100, 3), dtype=np.uint8))
 
-def test_create_gif_mixed_channels(tmp_path) -> None:
-    """_create_gif handles screenshots with mixed channel counts (RGB and RGBA)."""
-    _write_png(tmp_path / "screenshot_01.png", np.zeros((100, 100, 3), dtype=np.uint8))
-    _write_png(tmp_path / "screenshot_02.png", np.zeros((100, 100, 4), dtype=np.uint8))
-    _write_png(tmp_path / "screenshot_03.png", np.zeros((100, 100, 3), dtype=np.uint8))
+        assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
+        assert (tmp_path / "out.gif").exists()
 
-    assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
-    assert (tmp_path / "out.gif").exists()
+    def test_different_sizes(self, tmp_path) -> None:
+        """_create_gif resizes screenshots that differ from the first frame's dimensions."""
+        _write_png(tmp_path / "screenshot_01.png", np.zeros((100, 200, 3), dtype=np.uint8))
+        _write_png(tmp_path / "screenshot_02.png", np.zeros((120, 180, 3), dtype=np.uint8))
 
+        assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
+        assert (tmp_path / "out.gif").exists()
 
-def test_create_gif_different_sizes(tmp_path) -> None:
-    """_create_gif resizes screenshots that differ from the first frame's dimensions."""
-    _write_png(tmp_path / "screenshot_01.png", np.zeros((100, 200, 3), dtype=np.uint8))
-    _write_png(tmp_path / "screenshot_02.png", np.zeros((120, 180, 3), dtype=np.uint8))
-
-    assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
-    assert (tmp_path / "out.gif").exists()
-
-
-def test_create_gif_no_screenshots(tmp_path) -> None:
-    """_create_gif returns False when no screenshot files are present."""
-    assert _create_gif(tmp_path, tmp_path / "out.gif") is False
+    def test_no_screenshots(self, tmp_path) -> None:
+        """_create_gif returns False when no screenshot files are present."""
+        assert _create_gif(tmp_path, tmp_path / "out.gif") is False
 
 
-# ---------------------------------------------------------------------------
-# capture_marimo_preview
-# ---------------------------------------------------------------------------
+class TestCaptureMarimoPreview:
+    def test_rotate_default(self, tmp_path) -> None:
+        """capture_marimo_preview defaults to rotate=True when rotate is not specified."""
+        with (
+            patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+            patch("pyvista_wasm._cli._create_gif", return_value=True),
+        ):
+            mock_capture.return_value = tmp_path
+            (tmp_path / "screenshot_01.png").write_bytes(b"fake")
 
-
-def test_capture_marimo_preview_rotate_default(tmp_path) -> None:
-    """capture_marimo_preview defaults to rotate=True when rotate is not specified."""
-    with (
-        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
-        patch("pyvista_wasm._cli._create_gif", return_value=True),
-    ):
-        mock_capture.return_value = tmp_path
-        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
-
-        capture_marimo_preview(output=tmp_path / "out.gif")
-
-        assert mock_capture.call_args.kwargs["rotate"] is True
-
-
-def test_capture_marimo_preview_with_rotate(tmp_path) -> None:
-    """capture_marimo_preview passes rotate=True to _capture_marimo_screenshots."""
-    with (
-        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
-        patch("pyvista_wasm._cli._create_gif", return_value=True),
-    ):
-        mock_capture.return_value = tmp_path
-        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
-
-        capture_marimo_preview(output=tmp_path / "out.gif", rotate=True)
-
-        assert mock_capture.call_args.kwargs["rotate"] is True
-
-
-def test_capture_marimo_preview_with_no_rotate(tmp_path) -> None:
-    """capture_marimo_preview passes rotate=False to _capture_marimo_screenshots."""
-    with (
-        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
-        patch("pyvista_wasm._cli._create_gif", return_value=True),
-    ):
-        mock_capture.return_value = tmp_path
-        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
-
-        capture_marimo_preview(output=tmp_path / "out.gif", rotate=False)
-
-        assert mock_capture.call_args.kwargs["rotate"] is False
-
-
-def test_capture_marimo_preview_no_screenshots(tmp_path) -> None:
-    """capture_marimo_preview exits when no screenshots are captured."""
-    with patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture:
-        mock_capture.return_value = tmp_path
-
-        with pytest.raises(SystemExit, match="1"):
             capture_marimo_preview(output=tmp_path / "out.gif")
 
+            assert mock_capture.call_args.kwargs["rotate"] is True
 
-def test_capture_marimo_preview_gif_creation_fails(tmp_path) -> None:
-    """capture_marimo_preview exits when GIF creation fails."""
-    with (
-        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
-        patch("pyvista_wasm._cli._create_gif", return_value=False),
-    ):
-        mock_capture.return_value = tmp_path
-        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
+    def test_with_rotate(self, tmp_path) -> None:
+        """capture_marimo_preview passes rotate=True to _capture_marimo_screenshots."""
+        with (
+            patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+            patch("pyvista_wasm._cli._create_gif", return_value=True),
+        ):
+            mock_capture.return_value = tmp_path
+            (tmp_path / "screenshot_01.png").write_bytes(b"fake")
 
-        with pytest.raises(SystemExit, match="1"):
-            capture_marimo_preview(output=tmp_path / "out.gif")
+            capture_marimo_preview(output=tmp_path / "out.gif", rotate=True)
 
+            assert mock_capture.call_args.kwargs["rotate"] is True
 
-# ---------------------------------------------------------------------------
-# _capture_marimo_screenshots
-# ---------------------------------------------------------------------------
+    def test_with_no_rotate(self, tmp_path) -> None:
+        """capture_marimo_preview passes rotate=False to _capture_marimo_screenshots."""
+        with (
+            patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+            patch("pyvista_wasm._cli._create_gif", return_value=True),
+        ):
+            mock_capture.return_value = tmp_path
+            (tmp_path / "screenshot_01.png").write_bytes(b"fake")
 
+            capture_marimo_preview(output=tmp_path / "out.gif", rotate=False)
 
-@pytest.mark.playwright
-def test_capture_marimo_screenshots_with_rotate(tmp_path) -> None:
-    """_capture_marimo_screenshots creates 14 screenshots with rotation."""
-    mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
+            assert mock_capture.call_args.kwargs["rotate"] is False
 
-    def fake_screenshot(path: str) -> None:
-        Path(path).write_bytes(b"fake-png")
+    def test_no_screenshots(self, tmp_path) -> None:
+        """capture_marimo_preview exits when no screenshots are captured."""
+        with patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture:
+            mock_capture.return_value = tmp_path
 
-    mock_page.screenshot.side_effect = fake_screenshot
+            with pytest.raises(SystemExit, match="1"):
+                capture_marimo_preview(output=tmp_path / "out.gif")
 
-    with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
-        result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=True)
+    def test_gif_creation_fails(self, tmp_path) -> None:
+        """capture_marimo_preview exits when GIF creation fails."""
+        with (
+            patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+            patch("pyvista_wasm._cli._create_gif", return_value=False),
+        ):
+            mock_capture.return_value = tmp_path
+            (tmp_path / "screenshot_01.png").write_bytes(b"fake")
 
-    assert result == tmp_path / "screenshots"
-    assert mock_page.screenshot.call_count == 14
-    mock_context.close.assert_called_once()
-    mock_browser.close.assert_called_once()
-
-
-@pytest.mark.playwright
-def test_capture_marimo_screenshots_without_rotate(tmp_path) -> None:
-    """_capture_marimo_screenshots creates 14 screenshots without rotation."""
-    mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
-
-    def fake_screenshot(path: str) -> None:
-        Path(path).write_bytes(b"fake-png")
-
-    mock_page.screenshot.side_effect = fake_screenshot
-
-    with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
-        result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=False)
-
-    assert result == tmp_path / "screenshots"
-    assert mock_page.screenshot.call_count == 14
-    mock_context.close.assert_called_once()
-    mock_browser.close.assert_called_once()
+            with pytest.raises(SystemExit, match="1"):
+                capture_marimo_preview(output=tmp_path / "out.gif")
 
 
 @pytest.mark.playwright
-def test_capture_marimo_screenshots_handles_exception(tmp_path) -> None:
-    """_capture_marimo_screenshots handles exceptions and still closes browser."""
-    mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
-    mock_page.goto.side_effect = Exception("Connection refused")
+class TestCaptureMarimoScreenshots:
+    def test_with_rotate(self, tmp_path) -> None:
+        """_capture_marimo_screenshots creates 14 screenshots with rotation."""
+        mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
 
-    with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
-        result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=True)
+        def fake_screenshot(path: str) -> None:
+            Path(path).write_bytes(b"fake-png")
 
-    assert result == tmp_path / "screenshots"
-    mock_context.close.assert_called_once()
-    mock_browser.close.assert_called_once()
+        mock_page.screenshot.side_effect = fake_screenshot
+
+        with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
+            result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=True)
+
+        assert result == tmp_path / "screenshots"
+        assert mock_page.screenshot.call_count == 14
+        mock_context.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+
+    def test_without_rotate(self, tmp_path) -> None:
+        """_capture_marimo_screenshots creates 14 screenshots without rotation."""
+        mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
+
+        def fake_screenshot(path: str) -> None:
+            Path(path).write_bytes(b"fake-png")
+
+        mock_page.screenshot.side_effect = fake_screenshot
+
+        with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
+            result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=False)
+
+        assert result == tmp_path / "screenshots"
+        assert mock_page.screenshot.call_count == 14
+        mock_context.close.assert_called_once()
+        mock_browser.close.assert_called_once()
+
+    def test_handles_exception(self, tmp_path) -> None:
+        """_capture_marimo_screenshots handles exceptions and still closes browser."""
+        mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
+        mock_page.goto.side_effect = Exception("Connection refused")
+
+        with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
+            result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=True)
+
+        assert result == tmp_path / "screenshots"
+        mock_context.close.assert_called_once()
+        mock_browser.close.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -842,6 +842,8 @@ def _write_png(path: Path, array: np.ndarray) -> None:
 
 
 class TestCreateGif:
+    """Tests for the ``_create_gif`` helper."""
+
     def test_uniform_rgb(self, tmp_path) -> None:
         """_create_gif creates a GIF from uniformly-shaped RGB screenshots."""
         for i in range(1, 4):
@@ -875,6 +877,8 @@ class TestCreateGif:
 
 
 class TestCaptureMarimoPreview:
+    """Tests for the ``capture_marimo_preview`` command."""
+
     def test_rotate_default(self, tmp_path) -> None:
         """capture_marimo_preview defaults to rotate=True when rotate is not specified."""
         with (
@@ -937,6 +941,8 @@ class TestCaptureMarimoPreview:
 
 @pytest.mark.playwright
 class TestCaptureMarimoScreenshots:
+    """Tests for the ``_capture_marimo_screenshots`` helper."""
+
     def test_with_rotate(self, tmp_path) -> None:
         """_capture_marimo_screenshots creates 14 screenshots with rotation."""
         mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,10 +12,13 @@ import pytest
 import pyvista_wasm as pv
 from pyvista_wasm._cli import (
     _apply_camera_movement,
+    _capture_marimo_screenshots,
     _capture_stlite_screenshots,
+    _create_gif,
     _find_canvas_in_frames,
     _rotate_canvas_with_mouse,
     _wait_for_canvas_in_frames,
+    capture_marimo_preview,
     capture_preview,
     capture_stlite_preview,
     cli_main,
@@ -829,3 +832,174 @@ def test_plot_new_plotter_with_camera_movement() -> None:
     """Camera movement options work with new plotters (not just pickle)."""
     with patch("pyvista_wasm.Plotter.show"):
         cli_main(["plot", str(VTK_FILE), "--azimuth", "45", "--zoom", "1.5"])
+
+
+# ---------------------------------------------------------------------------
+# _create_gif
+# ---------------------------------------------------------------------------
+
+
+def _write_png(path: Path, array: np.ndarray) -> None:
+    """Save a numpy array as a PNG file."""
+    from PIL import Image  # noqa: PLC0415
+
+    Image.fromarray(array).save(path)
+
+
+def test_create_gif_uniform_rgb(tmp_path) -> None:
+    """_create_gif creates a GIF from uniformly-shaped RGB screenshots."""
+    for i in range(1, 4):
+        _write_png(tmp_path / f"screenshot_{i:02d}.png", np.zeros((100, 100, 3), dtype=np.uint8))
+
+    assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
+    assert (tmp_path / "out.gif").exists()
+
+
+def test_create_gif_mixed_channels(tmp_path) -> None:
+    """_create_gif handles screenshots with mixed channel counts (RGB and RGBA)."""
+    _write_png(tmp_path / "screenshot_01.png", np.zeros((100, 100, 3), dtype=np.uint8))
+    _write_png(tmp_path / "screenshot_02.png", np.zeros((100, 100, 4), dtype=np.uint8))
+    _write_png(tmp_path / "screenshot_03.png", np.zeros((100, 100, 3), dtype=np.uint8))
+
+    assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
+    assert (tmp_path / "out.gif").exists()
+
+
+def test_create_gif_different_sizes(tmp_path) -> None:
+    """_create_gif resizes screenshots that differ from the first frame's dimensions."""
+    _write_png(tmp_path / "screenshot_01.png", np.zeros((100, 200, 3), dtype=np.uint8))
+    _write_png(tmp_path / "screenshot_02.png", np.zeros((120, 180, 3), dtype=np.uint8))
+
+    assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True
+    assert (tmp_path / "out.gif").exists()
+
+
+def test_create_gif_no_screenshots(tmp_path) -> None:
+    """_create_gif returns False when no screenshot files are present."""
+    assert _create_gif(tmp_path, tmp_path / "out.gif") is False
+
+
+# ---------------------------------------------------------------------------
+# capture_marimo_preview
+# ---------------------------------------------------------------------------
+
+
+def test_capture_marimo_preview_rotate_default(tmp_path) -> None:
+    """capture_marimo_preview defaults to rotate=True when rotate is not specified."""
+    with (
+        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+        patch("pyvista_wasm._cli._create_gif", return_value=True),
+    ):
+        mock_capture.return_value = tmp_path
+        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
+
+        capture_marimo_preview(output=tmp_path / "out.gif")
+
+        assert mock_capture.call_args.kwargs["rotate"] is True
+
+
+def test_capture_marimo_preview_with_rotate(tmp_path) -> None:
+    """capture_marimo_preview passes rotate=True to _capture_marimo_screenshots."""
+    with (
+        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+        patch("pyvista_wasm._cli._create_gif", return_value=True),
+    ):
+        mock_capture.return_value = tmp_path
+        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
+
+        capture_marimo_preview(output=tmp_path / "out.gif", rotate=True)
+
+        assert mock_capture.call_args.kwargs["rotate"] is True
+
+
+def test_capture_marimo_preview_with_no_rotate(tmp_path) -> None:
+    """capture_marimo_preview passes rotate=False to _capture_marimo_screenshots."""
+    with (
+        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+        patch("pyvista_wasm._cli._create_gif", return_value=True),
+    ):
+        mock_capture.return_value = tmp_path
+        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
+
+        capture_marimo_preview(output=tmp_path / "out.gif", rotate=False)
+
+        assert mock_capture.call_args.kwargs["rotate"] is False
+
+
+def test_capture_marimo_preview_no_screenshots(tmp_path) -> None:
+    """capture_marimo_preview exits when no screenshots are captured."""
+    with patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture:
+        mock_capture.return_value = tmp_path
+
+        with pytest.raises(SystemExit, match="1"):
+            capture_marimo_preview(output=tmp_path / "out.gif")
+
+
+def test_capture_marimo_preview_gif_creation_fails(tmp_path) -> None:
+    """capture_marimo_preview exits when GIF creation fails."""
+    with (
+        patch("pyvista_wasm._cli._capture_marimo_screenshots") as mock_capture,
+        patch("pyvista_wasm._cli._create_gif", return_value=False),
+    ):
+        mock_capture.return_value = tmp_path
+        (tmp_path / "screenshot_01.png").write_bytes(b"fake")
+
+        with pytest.raises(SystemExit, match="1"):
+            capture_marimo_preview(output=tmp_path / "out.gif")
+
+
+# ---------------------------------------------------------------------------
+# _capture_marimo_screenshots
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.playwright
+def test_capture_marimo_screenshots_with_rotate(tmp_path) -> None:
+    """_capture_marimo_screenshots creates 14 screenshots with rotation."""
+    mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
+
+    def fake_screenshot(path: str) -> None:
+        Path(path).write_bytes(b"fake-png")
+
+    mock_page.screenshot.side_effect = fake_screenshot
+
+    with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
+        result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=True)
+
+    assert result == tmp_path / "screenshots"
+    assert mock_page.screenshot.call_count == 14
+    mock_context.close.assert_called_once()
+    mock_browser.close.assert_called_once()
+
+
+@pytest.mark.playwright
+def test_capture_marimo_screenshots_without_rotate(tmp_path) -> None:
+    """_capture_marimo_screenshots creates 14 screenshots without rotation."""
+    mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
+
+    def fake_screenshot(path: str) -> None:
+        Path(path).write_bytes(b"fake-png")
+
+    mock_page.screenshot.side_effect = fake_screenshot
+
+    with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
+        result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=False)
+
+    assert result == tmp_path / "screenshots"
+    assert mock_page.screenshot.call_count == 14
+    mock_context.close.assert_called_once()
+    mock_browser.close.assert_called_once()
+
+
+@pytest.mark.playwright
+def test_capture_marimo_screenshots_handles_exception(tmp_path) -> None:
+    """_capture_marimo_screenshots handles exceptions and still closes browser."""
+    mock_pw_cm, mock_page, mock_context, mock_browser = _make_mock_playwright()
+    mock_page.goto.side_effect = Exception("Connection refused")
+
+    with patch("playwright.sync_api.sync_playwright", return_value=mock_pw_cm):
+        result = _capture_marimo_screenshots(tmp_path, "http://example.com", rotate=True)
+
+    assert result == tmp_path / "screenshots"
+    mock_context.close.assert_called_once()
+    mock_browser.close.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -848,7 +848,8 @@ class TestCreateGif:
         """_create_gif creates a GIF from uniformly-shaped RGB screenshots."""
         for i in range(1, 4):
             _write_png(
-                tmp_path / f"screenshot_{i:02d}.png", np.zeros((100, 100, 3), dtype=np.uint8)
+                tmp_path / f"screenshot_{i:02d}.png",
+                np.zeros((100, 100, 3), dtype=np.uint8),
             )
 
         assert _create_gif(tmp_path, tmp_path / "out.gif", fps=2) is True

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest-cov
     playwright>=1.40
     pytest-playwright>=0.4.0
+    imageio>=2.28
     pillow>=9.0
 commands_pre =
     playwright install chromium

--- a/uv.lock
+++ b/uv.lock
@@ -588,6 +588,19 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
 name = "imagesize"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1973,6 +1986,7 @@ streamlit = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "imageio" },
     { name = "mypy" },
     { name = "pillow" },
     { name = "playwright" },
@@ -1984,6 +1998,7 @@ dev = [
     { name = "tox" },
 ]
 test = [
+    { name = "imageio" },
     { name = "pillow" },
     { name = "playwright" },
     { name = "pytest" },
@@ -2018,6 +2033,7 @@ provides-extras = ["dev", "docs", "marimo", "streamlit"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "imageio", specifier = ">=2.28.0,<2.38.0" },
     { name = "mypy", specifier = ">=1.0.0,<1.21.0" },
     { name = "pillow", specifier = ">=9.0.0,<13.0.0" },
     { name = "playwright", specifier = ">=1.40.0,<1.50.0" },
@@ -2029,6 +2045,7 @@ dev = [
     { name = "tox", specifier = ">=4.0.0,<4.54.0" },
 ]
 test = [
+    { name = "imageio", specifier = ">=2.28.0,<2.38.0" },
     { name = "pillow", specifier = ">=9.0.0,<13.0.0" },
     { name = "playwright", specifier = ">=1.40.0,<1.50.0" },
     { name = "pytest", specifier = ">=7.0.0,<9.1.0" },


### PR DESCRIPTION
## Summary

- Screenshots captured by the browser can be RGB or RGBA depending on the page render state, causing `np.stack` to fail when frames have mismatched channel counts.
- The previous fix only handled mismatched 2D dimensions (height/width) but skipped channel normalization.
- Convert every frame to RGB unconditionally so all frames have a uniform shape before being passed to imageio.

## Related

Fixes the failure in https://github.com/tkoyama010/pyvista-wasm/actions/runs/24807291682/job/72604294308