### PR TITLE
docs: add test conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@ No local setup is required. CI verifies the dev environment on every PR.
 - [Read the Docs](https://readthedocs.org) builds a documentation preview for every PR.
 - After creating a PR, monitor CI continuously, keep fixing and pushing until all checks pass.
 
+## Test conventions
+
+- Group related tests into a class named after the function or command under test (e.g. `TestCreateGif`, `TestCaptureMarimoPreview`).
+- Do not use comment banners (e.g. `# ---`) to separate test sections; use classes instead.
+
 ## PR instructions
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.


### PR DESCRIPTION
## Summary

- AI coding agents were organizing test sections with comment banners (`# ---`), which obscures pytest's native grouping and filtering capabilities.
- Document the class-based convention so agents (and humans) use `class TestFoo` instead.