### PR TITLE
docs: add project goal to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Project goal
+
+This repository aims to fully realize PyVista's API using vtk-wasm, enabling PyVista to run entirely in the browser via WebAssembly.
+
 ## Dev environment tips
 
 No local setup is required. CI verifies the dev environment on every PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-## Project goal
-
 This repository aims to fully realize PyVista's API using vtk-wasm, enabling PyVista to run entirely in the browser via WebAssembly.
 
 ## Dev environment tips

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This repository aims to fully realize PyVista's API using vtk-wasm, enabling PyVista to run entirely in the browser via WebAssembly.
 
+The architecture calls vtk-wasm from TypeScript: TypeScript acts as the glue layer that loads the vtk-wasm module and bridges its C++ VTK bindings to the Python-facing PyVista API.
+
 ## Dev environment tips
 
 No local setup is required. CI verifies the dev environment on every PR.


### PR DESCRIPTION
## Summary

- Adds a "Project goal" section at the top of `AGENTS.md` describing the repository's purpose: to fully realize PyVista's API using vtk-wasm so that PyVista runs entirely in the browser via WebAssembly.

## Why

Agents working in this repository need to understand the high-level purpose of the project so they can make better-informed decisions about scope, priorities, and API coverage.