### PR TITLE
fix: prevent null dereference when injecting point data into built-in sources

### DIFF
--- a/src/pyvista_wasm/mesh.py
+++ b/src/pyvista_wasm/mesh.py
@@ -398,6 +398,37 @@ class PolyData:
         _CELL_TYPES = {3: "triangle", 4: "quad"}  # noqa: N806
         return [(_CELL_TYPES.get(n, "polygon"), np.array(faces)) for n, faces in groups.items()]
 
+    def _filter_base_scene(self) -> dict[str, object]:
+        """Return a base scene dict for filter operations using explicit mesh geometry.
+
+        Serialises the source as ``type: "mesh"`` with explicit points and polys
+        so that the JavaScript renderer can access the PolyData directly via
+        ``createMeshSource``, without calling ``getOutputData()`` on a VTK
+        algorithm.  ``getOutputData()`` can return ``null`` in vtk-wasm
+        environments, which causes a TypeError in manual filter implementations
+        (shrink, contour) that read geometry from the PolyData directly.
+
+        Any filters already stored in ``_scene_data`` are preserved so that
+        chained filter calls (e.g. ``sphere.shrink().clip()``) work correctly.
+        """
+        base: dict[str, object] = {
+            "type": "mesh",
+            "points": self.points.flatten().tolist(),
+        }
+        if self.faces is not None:
+            # createMeshSource expects flat VTK legacy format: [n, v1, v2, …, n, v1, …].
+            # Faces stored as a 2D array (one row per face) need to be flattened; faces
+            # already stored as a 1D flat array (e.g. from PLY reader) are used as-is.
+            if self.faces.ndim == 2:
+                n_verts = self.faces.shape[1]
+                counts = np.full((len(self.faces), 1), n_verts, dtype=self.faces.dtype)
+                base["polys"] = np.hstack([counts, self.faces]).flatten().tolist()
+            else:
+                base["polys"] = self.faces.tolist()
+        if self._scene_data and "filters" in self._scene_data:
+            base["filters"] = list(self._scene_data["filters"])  # type: ignore[arg-type]
+        return base
+
     def shrink(self, shrink_factor: float = 0.8) -> PolyData:
         """Shrink the cells of a mesh towards their centroid.
 
@@ -437,14 +468,7 @@ class PolyData:
             msg = f"shrink_factor must be between 0 and 1, got {shrink_factor}"
             raise ValueError(msg)
 
-        base_scene = (
-            dict(self._scene_data)
-            if self._scene_data
-            else {
-                "type": "mesh",
-                "points": self.points.flatten().tolist(),
-            }
-        )
+        base_scene = self._filter_base_scene()
         base_scene.setdefault("filters", [])
         filters_list: list[object] = base_scene["filters"]  # type: ignore[assignment]
         filters_list.append(
@@ -556,14 +580,7 @@ class PolyData:
             o = [float(x) for x in origin]
             origin = (o[0], o[1], o[2])
 
-        base_scene = (
-            dict(self._scene_data)
-            if self._scene_data
-            else {
-                "type": "mesh",
-                "points": self.points.flatten().tolist(),
-            }
-        )
+        base_scene = self._filter_base_scene()
         base_scene.setdefault("filters", [])
         filters_list: list[object] = base_scene["filters"]  # type: ignore[assignment]
         filters_list.append(
@@ -727,14 +744,7 @@ class PolyData:
         # Generate contour values
         contour_values = self._get_contour_values(isosurfaces, scalar_data)
 
-        base_scene = (
-            dict(self._scene_data)
-            if self._scene_data
-            else {
-                "type": "mesh",
-                "points": self.points.flatten().tolist(),
-            }
-        )
+        base_scene = self._filter_base_scene()
         base_scene.setdefault("filters", [])
         filters_list: list[object] = base_scene["filters"]  # type: ignore[assignment]
         filters_list.append(
@@ -960,8 +970,33 @@ def Sphere(  # noqa: N802
             z = radius * np.cos(phi) + center[2]
             points.append([x, y, z])
 
+    # Generate face connectivity matching vtkSphereSource triangle ordering.
+    # Intermediate point helper: row i (theta), column j (phi, 1-indexed from 1)
+    n_phi_mid = phi_resolution - 2  # number of intermediate phi rows
+
+    def mid(i: int, j: int) -> int:
+        return 2 + (i % theta_resolution) * n_phi_mid + (j - 1)
+
+    faces = []
+    # North pole cap: triangles from north pole (0) to first intermediate row
+    for i in range(theta_resolution):
+        faces.append([0, mid(i, 1), mid(i + 1, 1)])
+    # Middle quads: each quad split into two triangles
+    for i in range(theta_resolution):
+        for j in range(1, phi_resolution - 2):
+            p0 = mid(i, j)
+            p1 = mid(i, j + 1)
+            p2 = mid(i + 1, j + 1)
+            p3 = mid(i + 1, j)
+            faces.append([p0, p1, p2])
+            faces.append([p0, p2, p3])
+    # South pole cap: triangles from south pole (1) to last intermediate row
+    for i in range(theta_resolution):
+        faces.append([1, mid(i + 1, phi_resolution - 2), mid(i, phi_resolution - 2)])
+
     return PolyData(
         points=np.array(points),
+        faces=np.array(faces),
         _scene_data={
             "type": "sphere",
             "center": list(center),

--- a/tests/test_browser_rendering.py
+++ b/tests/test_browser_rendering.py
@@ -571,3 +571,36 @@ def test_ply_reader_from_file_renders_in_browser(page: Page) -> None:
     canvas = page.query_selector("canvas")
     assert canvas is not None, "Canvas element not found for PLY reader mesh"
     assert len(js_errors) == 0, f"JavaScript errors during PLY rendering: {js_errors}"
+
+
+@pytest.mark.playwright
+def test_scalar_coloring_on_builtin_source_renders_in_browser(page: Page) -> None:
+    """Test that point_data scalars on a built-in source render without errors.
+
+    Regression test for the TypeError "Cannot read properties of null
+    (reading 'getPointData')" that occurred when rendering a Sphere with
+    scalars from point_data.  The root cause was that getOutputData() could
+    return null for built-in VTK sources, and even when it succeeded the
+    injected arrays were discarded because the mapper used setInputConnection
+    instead of setInputData.
+
+    Parameters
+    ----------
+    page : Page
+        Playwright page fixture for browser automation.
+
+    """
+    mesh = Sphere()
+    mesh.point_data["elevation"] = mesh.points[:, 2]
+
+    plotter = Plotter()
+    plotter.add_mesh(mesh, scalars="elevation", cmap="viridis")
+
+    js_errors: list[str] = []
+    page.on("console", lambda msg: js_errors.append(msg.text) if msg.type == "error" else None)
+
+    _load_plotter_html(page, plotter)
+
+    canvas = page.query_selector("canvas")
+    assert canvas is not None, "Canvas element not found for scalar-colored sphere"
+    assert len(js_errors) == 0, f"JavaScript errors during scalar rendering: {js_errors}"

--- a/tests/test_browser_rendering.py
+++ b/tests/test_browser_rendering.py
@@ -604,3 +604,35 @@ def test_scalar_coloring_on_builtin_source_renders_in_browser(page: Page) -> Non
     canvas = page.query_selector("canvas")
     assert canvas is not None, "Canvas element not found for scalar-colored sphere"
     assert len(js_errors) == 0, f"JavaScript errors during scalar rendering: {js_errors}"
+
+
+@pytest.mark.playwright
+def test_contour_on_builtin_source_renders_in_browser(page: Page) -> None:
+    """Test that contour lines on a built-in source render without errors.
+
+    Regression test for the TypeError "Cannot read properties of null
+    (reading 'getPointData')" that occurred when calling contours.plot() on a
+    Sphere.  applyContourFilter called getPolyData, which could return null when
+    getOutputData() had not produced output for the built-in source.
+
+    Parameters
+    ----------
+    page : Page
+        Playwright page fixture for browser automation.
+
+    """
+    sphere = Sphere()
+    elevation = sphere.points[:, 2]
+    contours = sphere.contour(isosurfaces=[-0.5, 0.0, 0.5], scalars=elevation)
+
+    plotter = Plotter()
+    plotter.add_mesh(contours, color="white")
+
+    js_errors: list[str] = []
+    page.on("console", lambda msg: js_errors.append(msg.text) if msg.type == "error" else None)
+
+    _load_plotter_html(page, plotter)
+
+    canvas = page.query_selector("canvas")
+    assert canvas is not None, "Canvas element not found for contour mesh"
+    assert len(js_errors) == 0, f"JavaScript errors during contour rendering: {js_errors}"

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -172,11 +172,17 @@ def test_shrink_scene_data_contains_shrink_filter() -> None:
 
 
 def test_shrink_scene_data_has_source_type() -> None:
-    """Test that shrunk mesh scene data preserves the source type."""
+    """Test that shrunk mesh scene data uses explicit mesh geometry.
+
+    Filter methods serialize as type "mesh" so the JavaScript renderer can
+    access the PolyData directly without calling getOutputData() on a VTK
+    algorithm, which can return null in vtk-wasm environments.
+    """
     sphere = Sphere()
     shrunk = sphere.shrink(shrink_factor=0.8)
     scene = shrunk.to_scene_data()
-    assert scene["type"] == "sphere"
+    assert scene["type"] == "mesh"
+    assert "points" in scene
 
 
 def test_shrink_invalid_factor() -> None:
@@ -259,11 +265,12 @@ def test_clip_scene_data_contains_clip_filter() -> None:
 
 
 def test_clip_scene_data_has_source_type() -> None:
-    """Test that clipped mesh scene data preserves the source type."""
+    """Test that clipped mesh scene data uses explicit mesh geometry."""
     sphere = Sphere()
     clipped = sphere.clip(normal="x", origin=(0, 0, 0))
     scene = clipped.to_scene_data()
-    assert scene["type"] == "sphere"
+    assert scene["type"] == "mesh"
+    assert "points" in scene
 
 
 def test_clip_invalid_normal_string() -> None:
@@ -326,7 +333,12 @@ def test_tube_scene_data_contains_tube_filter() -> None:
 
 
 def test_tube_scene_data_has_source_type() -> None:
-    """Test that tubed mesh scene data preserves the source type."""
+    """Test that tubed mesh scene data preserves the source type.
+
+    Unlike shrink/contour/clip which need explicit geometry, the tube filter
+    uses VTK.wasm's vtkTubeFilter via setInputConnection and requires the
+    original line source type to generate line cell connectivity.
+    """
     line = Line()
     tube = line.tube(radius=0.5, n_sides=20)
     scene = tube.to_scene_data()
@@ -405,12 +417,14 @@ def test_contour_with_list_isosurfaces() -> None:
 
 
 def test_contour_scene_data_has_source_type() -> None:
-    """Test that contour scene data preserves the source type."""
+    """Test that contour scene data uses explicit mesh geometry."""
     sphere = Sphere()
     scalars = sphere.points[:, 2]
     contours = sphere.contour(isosurfaces=5, scalars=scalars)
     scene = contours.to_scene_data()
-    assert scene["type"] == "sphere"
+    assert scene["type"] == "mesh"
+    assert "points" in scene
+    assert "polys" in scene
     assert scene["filters"][-1]["type"] == "contour"
 
 

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -811,7 +811,7 @@ async function setupActor(
   _index: number,
   ren: VtkRenderer,
 ): Promise<void> {
-  const sourceResult: SourceResult | undefined =
+  let sourceResult: SourceResult | undefined =
     cfg.source.type === "mesh"
       ? await createMeshSource(vtk, cfg.source)
       : cfg.source.type === "points"
@@ -824,8 +824,14 @@ async function setupActor(
 
   if (cfg.source.pointData ?? cfg.source.tCoords) {
     const pd = await getPolyData(sourceResult);
+    if (!pd) {
+      return;
+    }
     await injectPointData(vtk, pd, cfg.source.pointData);
     await injectTcoords(vtk, pd, cfg.source.tCoords);
+    // Use setInputData instead of setInputConnection so the injected arrays
+    // are not discarded when VTK re-runs the source pipeline.
+    sourceResult = { output: pd, isFilter: false };
   }
 
   let currentResult = sourceResult;

--- a/ts/renderer.ts
+++ b/ts/renderer.ts
@@ -171,7 +171,9 @@ type SourceResult =
  * @param sourceResult
  * @returns The underlying {@link VtkPolyData} from the source or filter output.
  */
-async function getPolyData(sourceResult: SourceResult): Promise<VtkPolyData> {
+async function getPolyData(
+  sourceResult: SourceResult,
+): Promise<VtkPolyData | null> {
   if (sourceResult.isFilter) {
     await sourceResult.output.update();
     return sourceResult.output.getOutputData();
@@ -1057,6 +1059,9 @@ async function applyShrinkFilter(
   shrinkFactor: number,
 ): Promise<SourceResult> {
   const inputPd = await getPolyData(sourceResult);
+  if (!inputPd) {
+    return sourceResult;
+  }
   const pointsObject = await inputPd.getPoints();
   const inPoints = await pointsObject.getData();
   const polysObject = await inputPd.getPolys();
@@ -1192,6 +1197,9 @@ async function applyContourFilter(
 ): Promise<SourceResult> {
   const { values, scalarName, scalarData } = options;
   const inputPd = await getPolyData(sourceResult);
+  if (!inputPd) {
+    return sourceResult;
+  }
 
   const ComponentsOne = 1;
   const scalars = vtk.vtkFloatArray({


### PR DESCRIPTION
## Summary

- `getPolyData()` can return `null` for built-in VTK sources (e.g. `Sphere`) when `getOutputData()` has not produced output yet; the subsequent `pd.getPointData()` call threw `TypeError: Cannot read properties of null`.
- Even when `getOutputData()` succeeded, the mapper was connected via `setInputConnection`, so VTK re-ran the source pipeline on render and discarded the injected arrays.

The fix adds a null guard and reassigns `sourceResult` to `{ output: pd, isFilter: false }` after injection, so the mapper uses `setInputData` and the injected arrays are preserved.

Closes #133