### PR TITLE
docs: align PR template with why-focused writing guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,33 +7,3 @@
 <!-- Link to the issue this PR addresses. If there's no issue, briefly explain why this change is needed. -->
 
 Closes #
-
-## Type of Change
-
-<!-- Mark the relevant option with an "x" (e.g., [x]). Note: PR title must follow Conventional Commits format. -->
-
-- [ ] `feat`: New feature or enhancement
-- [ ] `fix`: Bug fix
-- [ ] `docs`: Documentation changes
-- [ ] `style`: Code style changes (formatting, no logic change)
-- [ ] `refactor`: Code refactoring (no functional changes)
-- [ ] `perf`: Performance improvements
-- [ ] `test`: Adding or updating tests
-- [ ] `build`: Build system or dependency changes
-- [ ] `ci`: CI/CD configuration changes
-- [ ] `chore`: Other changes (maintenance, tooling, etc.)
-- [ ] `revert`: Revert a previous commit
-
-## Checklist
-
-<!-- Mark completed items with an "x" (e.g., [x]). -->
-
-- [ ] My PR title follows the [Conventional Commits](https://conventionalcommits.org) format (e.g., `feat: add new feature` or `fix: resolve issue`)
-- [ ] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md)
-- [ ] My code follows the project's code style (linting passes)
-- [ ] I have added/updated documentation as needed
-- [ ] Any dependent changes have been merged and published
-
-## Additional Notes
-
-<!-- Add any other context, concerns, or information that reviewers should know. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-## Description
+## Motivation
 
-<!-- Provide a clear and concise description of what this PR does. Include any relevant context, motivation, or background information. -->
+<!-- Explain why this change is needed. What problem does it solve? What is the context or background? -->
 
 ## Related Issue
 
@@ -31,19 +31,8 @@ Closes #
 - [ ] My PR title follows the [Conventional Commits](https://conventionalcommits.org) format (e.g., `feat: add new feature` or `fix: resolve issue`)
 - [ ] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md)
 - [ ] My code follows the project's code style (linting passes)
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
 - [ ] I have added/updated documentation as needed
-- [ ] I have updated type hints where applicable
 - [ ] Any dependent changes have been merged and published
-
-## Testing
-
-<!-- Describe the tests you ran and how to reproduce them. Include relevant details about your test configuration. -->
-
-## Screenshots/Examples (if applicable)
-
-<!-- If your changes include visual updates or new functionality, provide screenshots, GIFs, or code examples. -->
 
 ## Additional Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ No local setup is required. CI verifies the dev environment on every PR.
 ## PR instructions
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
+- When creating a PR, follow the template in `.github/pull_request_template.md`.
 - Write commit messages and PR descriptions to explain **why**; the message and descriptions should explain the motivation.
 - Remove commit messages and PR descriptions to explain **what**; the diff shows what changed.
 - Remove commit messages and PR descriptions to explain **test information**; the diff shows test code, and CI shows test results.


### PR DESCRIPTION
## Motivation

The existing PR template prompted contributors to describe "what this PR does" and included a "Testing" section. This contradicts the project's writing guidelines in AGENTS.md, which say to explain **why** (motivation) and to omit test information (visible in the diff and CI).

## Related Issue

N/A

## Type of Change

- [x] `docs`: Documentation changes

## Checklist

- [x] My PR title follows the [Conventional Commits](https://conventionalcommits.org) format (e.g., `feat: add new feature` or `fix: resolve issue`)
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] My code follows the project's code style (linting passes)
- [x] I have added/updated documentation as needed
- [x] Any dependent changes have been merged and published

## Additional Notes

Also adds a pointer in AGENTS.md so agents and contributors know to follow the template when creating PRs.