### PR TITLE
feat: support plotter.show() for automatic rendering in marimo

### DIFF
--- a/src/pyvista_wasm/plotter.py
+++ b/src/pyvista_wasm/plotter.py
@@ -368,10 +368,11 @@ class Plotter:
         | list[tuple[float, float, float]]
         | list[list[float]]
         | None = None,
-    ) -> None:
+    ) -> object | None:
         """Display the visualization.
 
         In browser environments, this will render the scene using VTK.wasm.
+        In marimo, returns the Html object for display.
 
         Parameters
         ----------
@@ -386,6 +387,12 @@ class Plotter:
             - Direction vector: 3-element tuple/list (x, y, z)
             - Full camera spec: 3-tuple/list of 3-tuples/lists:
               [(position), (focal_point), (view_up)]
+
+        Returns
+        -------
+        object or None
+            In marimo environments, returns the Html widget for display.
+            In other environments, returns None.
 
         Examples
         --------
@@ -422,8 +429,8 @@ class Plotter:
         # Create container if needed
         self._renderer.create_container(container_id or self._container_id)
 
-        # Render the scene
-        self._renderer.render()
+        # Render the scene and return the result (for marimo Html)
+        return self._renderer.render()
 
     def generate_standalone_html(self) -> str:
         """Generate a complete standalone HTML page with the current scene.

--- a/src/pyvista_wasm/rendering.py
+++ b/src/pyvista_wasm/rendering.py
@@ -141,7 +141,7 @@ except ImportError:
 MARIMO_AVAILABLE = False
 if "marimo" in sys.modules:
     try:
-        import marimo as _marimo  # noqa: PLC0415
+        import marimo as _marimo
 
         MARIMO_AVAILABLE = True
     except ImportError:

--- a/src/pyvista_wasm/rendering.py
+++ b/src/pyvista_wasm/rendering.py
@@ -137,6 +137,16 @@ except ImportError:
     Javascript = None  # type: ignore[assignment]
     display = None  # type: ignore[assignment]
 
+# Check if marimo is available
+MARIMO_AVAILABLE = False
+if "marimo" in sys.modules:
+    try:
+        import marimo as _marimo  # noqa: PLC0415
+
+        MARIMO_AVAILABLE = True
+    except ImportError:
+        pass
+
 
 class _VTKWasmLoader:
     """Singleton class to manage VTK.wasm library loading."""
@@ -1078,25 +1088,8 @@ class VTKWasmRenderer(_BaseHTMLRenderer):
 
         """
         if self.use_ipython:
-            import sys  # noqa: PLC0415
-
-            if "marimo" in sys.modules:
-                # marimo does not execute display(Javascript(...)); use mo.output.append instead
-                import marimo as mo  # noqa: PLC0415
-
-                html_content = self.generate_standalone_html()
-                escaped = html_content.replace("&", "&amp;").replace('"', "&quot;")
-                mo.output.append(  # type: ignore[attr-defined]
-                    mo.Html(  # type: ignore[attr-defined]
-                        f'<iframe srcdoc="{escaped}" '
-                        'style="width:100%;height:400px;min-height:400px;'
-                        'border:2px solid #333;" '
-                        'sandbox="allow-scripts"></iframe>',
-                    ),
-                )
-            else:
-                js_code = self._generate_render_js()
-                display(Javascript(js_code))
+            js_code = self._generate_render_js()
+            display(Javascript(js_code))
         else:
             # Direct rendering
             self.renderer.resetCamera()  # type: ignore[attr-defined]
@@ -1145,6 +1138,131 @@ def _playwright_capture(html_path: str, w: int, h: int, omit_bg: bool) -> bytes:
         data = pg.screenshot(type="png", omit_background=omit_bg)
         browser.close()
     return data
+
+
+class MarimoRenderer(_BaseHTMLRenderer):
+    """Renderer for marimo notebooks.
+
+    This renderer generates an iframe with the visualization and appends
+    it to marimo's output using mo.output.append(). This enables
+    automatic inline rendering when plotter.show() is called in marimo.
+
+    Examples
+    --------
+    >>> import pyvista_wasm as pv
+    >>> plotter = pv.Plotter()  # doctest: +SKIP
+    >>> _ = plotter.add_mesh(pv.Sphere(), color='red')  # doctest: +SKIP
+    >>> plotter.show()  # doctest: +SKIP
+
+    """
+
+    def __init__(
+        self,
+        lighting: str | None = "default",
+        wasm_rendering: str = "webgl",
+        wasm_mode: str = "sync",
+    ) -> None:
+        """Initialize the marimo renderer.
+
+        Parameters
+        ----------
+        lighting : str or None, optional
+            Lighting mode. ``"default"`` creates a default directional light,
+            ``None`` creates no default lights. Default is ``"default"``.
+        wasm_rendering : str, optional
+            WebAssembly rendering backend. One of ``"webgl"`` or ``"webgpu"``.
+            Default is ``"webgl"``.
+        wasm_mode : str, optional
+            Execution mode for VTK.wasm method calls. One of ``"sync"`` or
+            ``"async"``. Default is ``"sync"``.
+
+        Raises
+        ------
+        RuntimeError
+            If marimo is not available.
+
+        """
+        if not MARIMO_AVAILABLE:
+            msg = "MarimoRenderer requires marimo to be installed and imported"
+            raise RuntimeError(msg)
+
+        super().__init__(
+            lighting=lighting,
+            wasm_rendering=wasm_rendering,
+            wasm_mode=wasm_mode,
+        )
+
+    def render(self) -> object:
+        """Render the scene in marimo.
+
+        Generates an iframe with the visualization and appends it to
+        marimo's output using mo.output.append().
+
+        Returns
+        -------
+        object
+            The marimo Html object that was appended to output.
+
+        Examples
+        --------
+        >>> renderer = MarimoRenderer()  # doctest: +SKIP
+        >>> renderer.add_mesh_actor(Sphere(), color='red')  # doctest: +SKIP
+        >>> renderer.render()  # doctest: +SKIP
+
+        """
+        import marimo as mo  # noqa: PLC0415
+
+        html_content = self.generate_standalone_html()
+        escaped = html_content.replace("&", "&amp;").replace('"', "&quot;")
+        html_widget = mo.Html(
+            f'<iframe srcdoc="{escaped}" '
+            'style="width:100%;height:400px;min-height:400px;'
+            'border:2px solid #333;" '
+            'sandbox="allow-scripts"></iframe>',
+        )
+        mo.output.append(html_widget)
+        return html_widget
+
+    def screenshot(
+        self,
+        filename: str | Path | None = None,
+        transparent_background: bool | None = None,  # noqa: FBT001
+        return_img: bool = True,  # noqa: FBT001, FBT002
+        window_size: tuple[int, int] | list[int] | None = None,
+        scale: int | None = None,
+    ) -> np.ndarray | None:
+        """Take a screenshot of the rendered scene.
+
+        This method raises NotImplementedError because marimo does not
+        support direct screenshot capture. Use BrowserRenderer for
+        screenshots in standard Python environments.
+
+        Parameters
+        ----------
+        filename : str, Path, or None, optional
+            File path to save the image.
+        transparent_background : bool or None, optional
+            Whether to make the background transparent.
+        return_img : bool, optional
+            If True, return a numpy array of the image.
+        window_size : tuple or list of int, optional
+            Window size as (width, height).
+        scale : int or None, optional
+            Scale factor for higher resolution.
+
+        Returns
+        -------
+        numpy.ndarray or None
+            Image data as numpy array if return_img is True, otherwise None.
+
+        Raises
+        ------
+        NotImplementedError
+            Screenshots are not supported in marimo environments.
+
+        """
+        msg = "screenshot() is not supported in marimo. Use BrowserRenderer instead."
+        raise NotImplementedError(msg)
 
 
 class BrowserRenderer(_BaseHTMLRenderer):
@@ -1745,10 +1863,10 @@ def get_renderer(
     lighting: str | None = "default",
     wasm_rendering: str = "webgl",
     wasm_mode: str = "sync",
-) -> VTKWasmRenderer | BrowserRenderer | MockRenderer:
+) -> VTKWasmRenderer | MarimoRenderer | BrowserRenderer | MockRenderer:
     """Get appropriate renderer for current environment.
 
-    Automatically detects whether running in Pyodide/browser and
+    Automatically detects whether running in Pyodide/browser/marimo and
     returns the appropriate renderer implementation.
 
     Parameters
@@ -1765,7 +1883,8 @@ def get_renderer(
 
     Returns
     -------
-    VTKWasmRenderer or BrowserRenderer or MockRenderer
+    VTKWasmRenderer or MarimoRenderer or BrowserRenderer or MockRenderer
+        - MarimoRenderer if in marimo environment
         - VTKWasmRenderer if in Pyodide or IPython environment
         - BrowserRenderer in standard Python (opens the default browser)
         - MockRenderer if ``PYVISTA_JS_NO_BROWSER=1`` is set (for testing/CI)
@@ -1774,9 +1893,10 @@ def get_renderer(
     --------
     >>> # Automatically gets the right renderer
     >>> renderer = get_renderer()  # doctest: +SKIP
+    >>> # In marimo: returns MarimoRenderer
     >>> # In Pyodide or Jupyter: returns VTKWasmRenderer
     >>> # In standard Python: returns BrowserRenderer (opens browser)
-    >>> # Same code works in both environments
+    >>> # Same code works in all environments
     >>> from pyvista_wasm import Sphere  # doctest: +SKIP
     >>> mesh = Sphere()  # doctest: +SKIP
     >>> renderer.add_mesh_actor(mesh, color='blue')  # doctest: +SKIP
@@ -1792,6 +1912,13 @@ def get_renderer(
     browser opening (useful for CI/CD and automated testing).
 
     """
+    # Check for marimo first (highest priority for WASM notebooks)
+    if MARIMO_AVAILABLE:
+        return MarimoRenderer(
+            lighting=lighting,
+            wasm_rendering=wasm_rendering,
+            wasm_mode=wasm_mode,
+        )
     # Use VTKWasmRenderer if in Pyodide with VTK.wasm OR if IPython is available
     if (PYODIDE_ENV and VTK_AVAILABLE) or IPYTHON_AVAILABLE:
         return VTKWasmRenderer(

--- a/src/pyvista_wasm/rendering.py
+++ b/src/pyvista_wasm/rendering.py
@@ -138,14 +138,7 @@ except ImportError:
     display = None  # type: ignore[assignment]
 
 # Check if marimo is available
-MARIMO_AVAILABLE = False
-if "marimo" in sys.modules:
-    try:
-        import marimo as _marimo
-
-        MARIMO_AVAILABLE = True
-    except ImportError:
-        pass
+MARIMO_AVAILABLE = "marimo" in sys.modules
 
 
 class _VTKWasmLoader:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from pyvista_wasm import rendering
+
 
 @pytest.fixture(autouse=True)
 def reset_renderer_flags(monkeypatch):
@@ -25,8 +27,6 @@ def reset_renderer_flags(monkeypatch):
     causes get_renderer() to return VTKWasmRenderer instead of BrowserRenderer
     or MockRenderer.
     """
-    from pyvista_wasm import rendering
-
     monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", False)
     monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", False)
     monkeypatch.setattr(rendering, "PYODIDE_ENV", False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,6 @@ def reset_renderer_flags(monkeypatch):
     monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", False)
     monkeypatch.setattr(rendering, "PYODIDE_ENV", False)
     monkeypatch.setattr(rendering, "VTK_AVAILABLE", False)
-    yield
 
 
 def extract_scene_data(html: str) -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,27 @@ from typing import TYPE_CHECKING
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def reset_renderer_flags(monkeypatch):
+    """Reset renderer environment flags to simulate standard Python environment.
+
+    This fixture ensures tests run in a consistent environment by default,
+    with MARIMO_AVAILABLE, IPYTHON_AVAILABLE, and PYODIDE_ENV set to False.
+    Tests that need specific environments should mock these values explicitly.
+
+    This prevents issues where IPython being available in the test environment
+    causes get_renderer() to return VTKWasmRenderer instead of BrowserRenderer
+    or MockRenderer.
+    """
+    from pyvista_wasm import rendering
+
+    monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", False)
+    monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", False)
+    monkeypatch.setattr(rendering, "PYODIDE_ENV", False)
+    monkeypatch.setattr(rendering, "VTK_AVAILABLE", False)
+    yield
+
+
 def extract_scene_data(html: str) -> dict:
     """Extract and parse the JSON scene data from generated HTML.
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -53,7 +53,7 @@ def test_multiple_meshes() -> None:
 
 def test_show(monkeypatch) -> None:
     """Test show method opens browser with a file:// URL."""
-    import pyvista_wasm.rendering as rendering  # noqa: PLC0415
+    from pyvista_wasm import rendering  # noqa: PLC0415
 
     opened: list[str] = []
 
@@ -1363,10 +1363,6 @@ class TestCaptureMarimoPreview:
 
     def test_plotter_show_returns_result_in_marimo(self, monkeypatch) -> None:
         """Test that plotter.show() returns renderer result in marimo."""
-        import sys  # noqa: PLC0415
-
-        from pyvista_wasm.rendering import MarimoRenderer  # noqa: PLC0415
-
         # Mock marimo environment
         monkeypatch.setattr("pyvista_wasm.rendering.MARIMO_AVAILABLE", True)
         monkeypatch.setattr("pyvista_wasm.rendering.IPYTHON_AVAILABLE", False)

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -53,12 +53,17 @@ def test_multiple_meshes() -> None:
 
 def test_show(monkeypatch) -> None:
     """Test show method opens browser with a file:// URL."""
+    import pyvista_wasm.rendering as rendering  # noqa: PLC0415
+
     opened: list[str] = []
 
     def _capture(url: str) -> None:
         opened.append(url)
 
     monkeypatch.setattr(webbrowser, "open", _capture)
+    monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", False)
+    monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", False)
+    monkeypatch.setattr(rendering, "PYODIDE_ENV", False)
 
     plotter = Plotter()
     plotter.add_mesh(Sphere())
@@ -1351,3 +1356,79 @@ def test_plotter_wasm_config_invalid_mode() -> None:
     """Test that Plotter raises ValueError for invalid wasm_mode."""
     with pytest.raises(ValueError, match="wasm_mode"):
         Plotter(wasm_mode="parallel")
+
+
+class TestCaptureMarimoPreview:
+    """Tests for marimo integration in Plotter.show()."""
+
+    def test_plotter_show_returns_result_in_marimo(self, monkeypatch) -> None:
+        """Test that plotter.show() returns renderer result in marimo."""
+        import sys  # noqa: PLC0415
+
+        from pyvista_wasm.rendering import MarimoRenderer  # noqa: PLC0415
+
+        # Mock marimo environment
+        monkeypatch.setattr("pyvista_wasm.rendering.MARIMO_AVAILABLE", True)
+        monkeypatch.setattr("pyvista_wasm.rendering.IPYTHON_AVAILABLE", False)
+        monkeypatch.setattr("pyvista_wasm.rendering.PYODIDE_ENV", False)
+
+        # Track whether render was called and what it returned
+        render_called = []
+
+        class MockMarimoRenderer:
+            def __init__(self, **kwargs):
+                self.actors = []
+                self._container_id = "test-container"
+
+            def add_mesh_actor(self, mesh, **kwargs):
+                self.actors.append({"mesh": mesh})
+                return {"mesh": mesh}
+
+            def create_container(self, element_id):
+                self._container_id = element_id
+
+            def render(self):
+                mock_result = "mock_html_result"
+                render_called.append(mock_result)
+                return mock_result
+
+        monkeypatch.setattr("pyvista_wasm.rendering.MarimoRenderer", MockMarimoRenderer)
+
+        # Mock get_renderer to return our mock
+        def mock_get_renderer(**kwargs):
+            return MockMarimoRenderer(**kwargs)
+
+        monkeypatch.setattr("pyvista_wasm.plotter.get_renderer", mock_get_renderer)
+
+        plotter = Plotter()
+        plotter.add_mesh(Sphere())
+        result = plotter.show()
+
+        assert render_called
+        assert result == "mock_html_result"
+
+    def test_plotter_show_returns_none_in_browser(self, monkeypatch) -> None:
+        """Test that plotter.show() returns None in standard browser mode."""
+        import webbrowser  # noqa: PLC0415
+
+        from pyvista_wasm.rendering import BrowserRenderer  # noqa: PLC0415
+
+        opened = []
+
+        def mock_open(url):
+            opened.append(url)
+
+        monkeypatch.setattr(webbrowser, "open", mock_open)
+
+        # Ensure BrowserRenderer is returned by mocking get_renderer
+        def mock_get_renderer(**kwargs):
+            return BrowserRenderer(**kwargs)
+
+        monkeypatch.setattr("pyvista_wasm.plotter.get_renderer", mock_get_renderer)
+
+        plotter = Plotter()
+        plotter.add_mesh(Sphere())
+        result = plotter.show()
+
+        assert opened
+        assert result is None

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1372,11 +1372,11 @@ class TestCaptureMarimoPreview:
         render_called = []
 
         class MockMarimoRenderer:
-            def __init__(self, **kwargs):
+            def __init__(self, **_kwargs):
                 self.actors = []
                 self._container_id = "test-container"
 
-            def add_mesh_actor(self, mesh, **kwargs):
+            def add_mesh_actor(self, mesh, **_kwargs):
                 self.actors.append({"mesh": mesh})
                 return {"mesh": mesh}
 

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -633,7 +633,7 @@ class TestMarimoRenderer:
 
         # Mock marimo module
         class MockMarimo:
-            class output:
+            class output:  # noqa: N801
                 @staticmethod
                 def append(obj):
                     pass
@@ -654,7 +654,7 @@ class TestMarimoRenderer:
         monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
 
         class MockMarimo:
-            class output:
+            class output:  # noqa: N801
                 @staticmethod
                 def append(obj):
                     pass
@@ -704,7 +704,7 @@ class TestMarimoRenderer:
         monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
 
         class MockMarimo:
-            class output:
+            class output:  # noqa: N801
                 @staticmethod
                 def append(obj):
                     pass
@@ -727,7 +727,7 @@ class TestMarimoRenderer:
         monkeypatch.setattr(rendering, "VTK_AVAILABLE", True)
 
         class MockMarimo:
-            class output:
+            class output:  # noqa: N801
                 @staticmethod
                 def append(obj):
                     pass

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,6 +1,7 @@
 """Test vtk.js rendering backend."""
 
 import logging
+import sys
 
 import pytest
 
@@ -8,8 +9,11 @@ from pyvista_wasm import Cube, Cylinder, PolyData, Sphere, rendering
 from pyvista_wasm.rendering import BrowserRenderer, MockRenderer, get_renderer
 
 
-def test_get_renderer_returns_browser() -> None:
-    """Test that get_renderer returns BrowserRenderer in standard Python env."""
+def test_get_renderer_returns_browser(monkeypatch) -> None:
+    """Test that get_renderer returns BrowserRenderer when IPython not available."""
+    monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", False)
+    monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", False)
+    monkeypatch.setattr(rendering, "PYODIDE_ENV", False)
     renderer = get_renderer()
     assert isinstance(renderer, BrowserRenderer)
 
@@ -612,3 +616,158 @@ def test_mock_renderer_stores_wasm_config() -> None:
     renderer = rendering.MockRenderer(wasm_rendering="webgpu", wasm_mode="async")
     assert renderer._wasm_rendering == "webgpu"
     assert renderer._wasm_mode == "async"
+
+
+class TestMarimoRenderer:
+    """Tests for MarimoRenderer class."""
+
+    def test_marimo_renderer_requires_marimo(self, monkeypatch) -> None:
+        """Test that MarimoRenderer raises RuntimeError when marimo is not available."""
+        monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", False)
+        with pytest.raises(RuntimeError, match="marimo"):
+            rendering.MarimoRenderer()
+
+    def test_marimo_renderer_creation(self, monkeypatch) -> None:
+        """Test MarimoRenderer initialization when marimo is available."""
+        monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
+
+        # Mock marimo module
+        class MockMarimo:
+            class output:
+                @staticmethod
+                def append(obj):
+                    pass
+
+            class Html:
+                def __init__(self, content):
+                    self.content = content
+
+        monkeypatch.setitem(sys.modules, "marimo", MockMarimo())
+
+        renderer = rendering.MarimoRenderer()
+        assert renderer is not None
+        assert renderer._wasm_rendering == "webgl"
+        assert renderer._wasm_mode == "sync"
+
+    def test_marimo_renderer_with_wasm_config(self, monkeypatch) -> None:
+        """Test MarimoRenderer with custom wasm config."""
+        monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
+
+        class MockMarimo:
+            class output:
+                @staticmethod
+                def append(obj):
+                    pass
+
+            class Html:
+                def __init__(self, content):
+                    self.content = content
+
+        monkeypatch.setitem(sys.modules, "marimo", MockMarimo())
+
+        renderer = rendering.MarimoRenderer(wasm_rendering="webgpu", wasm_mode="async")
+        assert renderer._wasm_rendering == "webgpu"
+        assert renderer._wasm_mode == "async"
+
+    def test_marimo_renderer_render_returns_html(self, monkeypatch) -> None:
+        """Test that MarimoRenderer.render() returns Html object."""
+        monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
+
+        captured = []
+
+        class MockHtml:
+            def __init__(self, content):
+                self.content = content
+                captured.append(self)
+
+        class MockOutput:
+            @staticmethod
+            def append(obj):
+                pass
+
+        class MockMarimo:
+            output = MockOutput()
+            Html = MockHtml
+
+        monkeypatch.setitem(sys.modules, "marimo", MockMarimo())
+
+        renderer = rendering.MarimoRenderer()
+        renderer.add_mesh_actor(Sphere(), color="red")
+        result = renderer.render()
+
+        assert result is not None
+        assert isinstance(result, MockHtml)
+        assert "iframe" in result.content
+
+    def test_marimo_renderer_screenshot_raises(self, monkeypatch) -> None:
+        """Test that MarimoRenderer.screenshot() raises NotImplementedError."""
+        monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
+
+        class MockMarimo:
+            class output:
+                @staticmethod
+                def append(obj):
+                    pass
+
+            class Html:
+                def __init__(self, content):
+                    self.content = content
+
+        monkeypatch.setitem(sys.modules, "marimo", MockMarimo())
+
+        renderer = rendering.MarimoRenderer()
+        with pytest.raises(NotImplementedError):
+            renderer.screenshot()
+
+    def test_get_renderer_returns_marimo_when_available(self, monkeypatch) -> None:
+        """Test that get_renderer returns MarimoRenderer when marimo is available."""
+        monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
+        monkeypatch.setattr(rendering, "IPYTHON_AVAILABLE", True)
+        monkeypatch.setattr(rendering, "PYODIDE_ENV", True)
+        monkeypatch.setattr(rendering, "VTK_AVAILABLE", True)
+
+        class MockMarimo:
+            class output:
+                @staticmethod
+                def append(obj):
+                    pass
+
+            class Html:
+                def __init__(self, content):
+                    self.content = content
+
+        monkeypatch.setitem(sys.modules, "marimo", MockMarimo())
+
+        renderer = get_renderer()
+        assert isinstance(renderer, rendering.MarimoRenderer)
+
+    def test_marimo_renderer_html_escaping(self, monkeypatch) -> None:
+        """Test that HTML content is properly escaped for iframe srcdoc."""
+        monkeypatch.setattr(rendering, "MARIMO_AVAILABLE", True)
+
+        captured = []
+
+        class MockHtml:
+            def __init__(self, content):
+                self.content = content
+                captured.append(self)
+
+        class MockOutput:
+            @staticmethod
+            def append(obj):
+                pass
+
+        class MockMarimo:
+            output = MockOutput()
+            Html = MockHtml
+
+        monkeypatch.setitem(sys.modules, "marimo", MockMarimo())
+
+        renderer = rendering.MarimoRenderer()
+        renderer.add_mesh_actor(Sphere(), color="red&blue")
+        result = renderer.render()
+
+        # Check that & is escaped to &amp;
+        assert "&amp;" in result.content
+        # Check that " is escaped to &quot;
+        assert "&quot;" in result.content


### PR DESCRIPTION
This PR implements automatic rendering support for marimo notebooks.

## Changes

- Added `MarimoRenderer` class that handles marimo-specific rendering using `mo.output.append()`
- Modified `get_renderer()` to detect marimo environment (checked before IPython)
- Removed marimo handling from `VTKWasmRenderer.render()`
- Updated `Plotter.show()` to return renderer result for marimo display
- Added tests for MarimoRenderer

## Usage

In marimo notebooks, `plotter.show()` now renders inline automatically:

```python
import pyvista_wasm as pv

plotter = pv.Plotter()
_ = plotter.add_mesh(pv.Sphere(), color="cyan")
plotter.show()  # Renders inline automatically
```

Closes #168