### PR TITLE
feat: add shfmt to pre-commit for shell script formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,11 @@ repos:
       - id: biome-check
         additional_dependencies: ["@biomejs/biome@2.4.10"]
 
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.11.0-1
+    hooks:
+      - id: shfmt
+
   - repo: https://github.com/scientific-python/cookie
     rev: 2026.04.04
     hooks:


### PR DESCRIPTION
## Motivation

Shell scripts in the repository had no automated formatting enforcement. Adding `shfmt` ensures consistent style and reduces unnecessary review noise as shell scripts are added over time.

## Related Issue

Closes #173