### PR TITLE
chore: add shellcheck to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,11 @@ repos:
       - id: biome-check
         additional_dependencies: ["@biomejs/biome@2.4.10"]
 
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.11.0-1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,11 @@ repos:
       - id: biome-check
         additional_dependencies: ["@biomejs/biome@2.4.10"]
 
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.11.0-1
+    hooks:
+      - id: shfmt
+
   - repo: https://github.com/scientific-python/cookie
     rev: 2026.04.04
     hooks:


### PR DESCRIPTION
## Motivation

Shell scripts in the repository had no static analysis. shellcheck is the de-facto standard linter for shell scripts and catches bugs, style issues, and portability problems early.

## Related Issue

Closes #174