### PR TITLE
chore(deps): bump gitpython to >=3.1.50 and add mistune as direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,10 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-  "gitpython>=3.1.47",
+  "gitpython>=3.1.50",
   "jinja2>=3.1.0,<3.2.0",
   "lazy-loader>=0.4.0,<0.6.0",
+  "mistune>=3.2.1",
   "numpy>=2.0.0,<2.5.0",
   "typer>=0.9.0,<0.26.0",
 ]


### PR DESCRIPTION
## Motivation

`gitpython` minimum version is bumped from `>=3.1.47` to `>=3.1.50` to align with the version already resolved in the lock file.

`mistune` is added explicitly to the project dependencies so its minimum version (`>=3.2.1`) is enforced at the `pyproject.toml` level rather than relying on transitive resolution alone.

## Related Issue

Closes #