### PR TITLE
chore: update VTK.wasm binary to 9.6.20260510

### DIFF
--- a/packages/vtk-wasm-binary/package.json
+++ b/packages/vtk-wasm-binary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyvista-wasm/vtk-wasm-binary",
-  "version": "9.6.20260228",
+  "version": "9.6.20260510",
   "description": "Mirrored VTK.wasm binary for pyvista-wasm (served via jsDelivr CDN)",
   "license": "BSD-3-Clause",
   "repository": {

--- a/src/pyvista_wasm/rendering.py
+++ b/src/pyvista_wasm/rendering.py
@@ -46,7 +46,7 @@ For manual loading or custom versions:
     <script
       src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
       id="vtk-wasm"
-      data-url="https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@9.6.20260228/vtk-wasm32-emscripten.tar.gz"
+      data-url="https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@9.6.20260510/vtk-wasm32-emscripten.tar.gz"
     ></script>
 
 Examples
@@ -105,7 +105,7 @@ _jinja_env = Environment(undefined=StrictUndefined, autoescape=False)  # noqa: S
 
 # VTK.wasm CDN URLs used across renderers
 _VTKWASM_UMD = "https://unpkg.com/@kitware/vtk-wasm@1.7.4/vtk-umd.js"
-_VTKWASM_VERSION = "9.6.20260228"
+_VTKWASM_VERSION = "9.6.20260510"
 _VTKWASM_DATA_URL = (
     "https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary"
     f"@{_VTKWASM_VERSION}/vtk-wasm32-emscripten.tar.gz"

--- a/src/pyvista_wasm/templates/streamlit.html
+++ b/src/pyvista_wasm/templates/streamlit.html
@@ -22,7 +22,7 @@
         <script
           src="https://unpkg.com/@kitware/vtk-wasm@1.7.4/vtk-umd.js"
           id="vtk-wasm"
-          data-url="https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@9.6.20260228/vtk-wasm32-emscripten.tar.gz"
+          data-url="https://cdn.jsdelivr.net/npm/@pyvista-wasm/vtk-wasm-binary@9.6.20260510/vtk-wasm32-emscripten.tar.gz"
         ></script>
     </head>
     <body>


### PR DESCRIPTION
Update VTK.wasm binary from `9.6.20260228` to `9.6.20260510`.

Detected by the [check-vtk-wasm-update](https://github.com/tkoyama010/pyvista-wasm/actions/workflows/check-vtk-wasm-update.yml) workflow.

Once merged, the [mirror-vtk-wasm](https://github.com/tkoyama010/pyvista-wasm/actions/workflows/mirror-vtk-wasm.yml) workflow will automatically publish the new binary to npm.